### PR TITLE
fix : updated denoiser values according to last DPF Sound API

### DIFF
--- a/tests/tests_xtract/test_xtract.py
+++ b/tests/tests_xtract/test_xtract.py
@@ -154,7 +154,7 @@ def test_xtract_process(dpf_sound_test_server):
     ## Creating noise profile with Xtract helper (white noise level)
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
 
     # Setting tonal parameters
@@ -197,7 +197,7 @@ def test_xtract_get_output_warns(dpf_sound_test_server):
     ## Creating noise profile with Xtract helper (white noise level)
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
 
     # Setting tonal parameters
@@ -230,9 +230,8 @@ def test_xtract_get_output_as_np_array_warns(dpf_sound_test_server):
     ## Creating noise profile with Xtract helper (white noise level)
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
-
     # Setting tonal parameters
     params_tonal = XtractTonalParameters()
     params_tonal.regularity = 1.0
@@ -263,7 +262,7 @@ def test_xtract_get_output(dpf_sound_test_server):
     ## Creating noise profile with Xtract helper (white noise level)
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
 
     # Setting tonal parameters
@@ -309,7 +308,7 @@ def test_xtract_get_output_noprocess(dpf_sound_test_server):
     ## Creating noise profile with Xtract helper (white noise level)
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
 
     # Setting tonal parameters
@@ -348,7 +347,7 @@ def test_xtract_get_output_fc(dpf_sound_test_server):
     ## Creating noise profile with Xtract helper (white noise level)
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
 
     # Setting tonal parameters
@@ -416,7 +415,7 @@ def test_xtract_get_output_as_nparray(dpf_sound_test_server):
     ## Creating noise profile with Xtract helper (white noise level)
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
 
     # Setting tonal parameters
@@ -477,7 +476,7 @@ def test_xtract_get_output_fc_as_nparray(dpf_sound_test_server):
     ## Creating noise profile with Xtract helper (white noise level)
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
 
     # Setting tonal parameters
@@ -555,7 +554,7 @@ def test_xtract_setters(dpf_sound_test_server):
     ## Creating noise profile with Xtract helper (white noise level)
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
 
     # Setting tonal parameters
@@ -602,7 +601,7 @@ def test_xtract_plot_output(mock_show, dpf_sound_test_server):
     ## Creating noise profile with Xtract helper (white noise level)
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
 
     # Setting tonal parameters
@@ -640,7 +639,7 @@ def test_xtract_plot_output_fc(mock_show, dpf_sound_test_server):
     ## Creating noise profile with Xtract helper (white noise level)
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
 
     # Setting tonal parameters

--- a/tests/tests_xtract/test_xtract_denoiser.py
+++ b/tests/tests_xtract/test_xtract_denoiser.py
@@ -104,7 +104,7 @@ def test_xtract_process(dpf_sound_test_server):
     # Setting Denoiser parameters
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
     xtract_denoiser = XtractDenoiser(bird_plus_idle_sig, params_denoiser)
     xtract_denoiser.process()
@@ -142,7 +142,7 @@ def test_xtract_denoiser_get_output_warns(dpf_sound_test_server):
     # Setting Denoiser parameters
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
     xtract_denoiser = XtractDenoiser(bird_plus_idle_sig, params_denoiser)
 
@@ -160,7 +160,7 @@ def test_xtract_denoiser_get_output_np_array_warns(dpf_sound_test_server):
     # Setting Denoiser parameters
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
     xtract_denoiser = XtractDenoiser(bird_plus_idle_sig, params_denoiser)
 
@@ -178,7 +178,7 @@ def test_xtract_denoiser_get_output(dpf_sound_test_server):
     # Setting Denoiser parameters
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
     xtract_denoiser = XtractDenoiser(bird_plus_idle_sig, params_denoiser)
     xtract_denoiser.process()
@@ -210,7 +210,7 @@ def test_xtract_denoiser_get_output_noprocess(dpf_sound_test_server):
     # Setting Denoiser parameters
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
     xtract_denoiser = XtractDenoiser(bird_plus_idle_sig, params_denoiser)
     xtract_denoiser.process()
@@ -231,7 +231,7 @@ def test_xtract_denoiser_get_output_fc(dpf_sound_test_server):
     # Setting Denoiser parameters
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
     xtract_denoiser = XtractDenoiser(bird_plus_idle_sig, params_denoiser)
     xtract_denoiser.process()
@@ -276,7 +276,7 @@ def test_xtract_denoiser_get_output_as_nparray(dpf_sound_test_server):
     # Setting Denoiser parameters
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
     xtract_denoiser = XtractDenoiser(bird_plus_idle_sig, params_denoiser)
     xtract_denoiser.process()
@@ -311,7 +311,7 @@ def test_xtract_denoiser_get_output_fc_as_nparray(dpf_sound_test_server):
     # Setting Denoiser parameters
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
     xtract_denoiser = XtractDenoiser(bird_plus_idle_sig, params_denoiser)
     xtract_denoiser.process()
@@ -339,7 +339,7 @@ def test_xtract_denoiser_setters(dpf_sound_test_server):
     # Setting Denoiser parameters
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
     xtract_denoiser = XtractDenoiser(bird_plus_idle_sig, params_denoiser)
     xtract_denoiser.process()
@@ -365,7 +365,7 @@ def test_xtract_denoiser_plot_output(mock_show, dpf_sound_test_server):
     # Setting Denoiser parameters
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
     xtract_denoiser = XtractDenoiser(bird_plus_idle_sig, params_denoiser)
     xtract_denoiser.process()
@@ -386,7 +386,7 @@ def test_xtract_denoiser_plot_output_fc(mock_show, dpf_sound_test_server):
     # Setting Denoiser parameters
     params_denoiser = XtractDenoiserParameters()
     params_denoiser.noise_psd = params_denoiser.create_noise_psd_from_white_noise_level(
-        -6.0, 44100.0, 50
+        -6.0 + 94.0, 44100.0, 50
     )
     xtract_denoiser = XtractDenoiser(bird_plus_idle_sig, params_denoiser)
     xtract_denoiser.process()

--- a/tests/tests_xtract/test_xtract_denoiser_parameters.py
+++ b/tests/tests_xtract/test_xtract_denoiser_parameters.py
@@ -60,7 +60,7 @@ def test_xtract_denoiser_parameters_generate_noise_psd_from_white_noise_level(
     xtract_denoiser_parameters = XtractDenoiserParameters()
 
     noise_psd = xtract_denoiser_parameters.create_noise_psd_from_white_noise_level(
-        white_noise_level=(40.0), sampling_frequency=44100.0, window_length=50
+        white_noise_level=(40.0 + 94.0), sampling_frequency=44100.0, window_length=50
     )
 
     noise = noise_psd.data


### PR DESCRIPTION
DPF Sound docker container and contains a slightly different API for the operator `create_noise_profile_from_white_noise_power`, that caused a bug in the automatic tests. Now fixed.