### PR TITLE
fix: OS classifier should be OS agnostic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
-    "Operating System :: Windows",
+    "Operating System :: OS Independent",
 ]
 dependencies = [
     "ansys-dpf-core>=0.9.0,<1",


### PR DESCRIPTION
The library itself can run on any OS. Ansys Sound is only Windows based