### PR TITLE
fix: Missing BLACKMAN window type in PSD and STFT classes

### DIFF
--- a/doc/changelog.d/103.fixed.md
+++ b/doc/changelog.d/103.fixed.md
@@ -1,0 +1,1 @@
+fix: Missing BLACKMAN window type in PSD and STFT classes

--- a/src/ansys/sound/core/spectral_processing/power_spectral_density.py
+++ b/src/ansys/sound/core/spectral_processing/power_spectral_density.py
@@ -117,7 +117,15 @@ class PowerSpectralDensity(SpectralProcessingParent):
     @window_type.setter
     def window_type(self, value: str):
         """Set window type."""
-        if value not in ["BLACKMANHARRIS", "HANN", "HAMMING", "KAISER", "BARTLETT", "RECTANGULAR"]:
+        if value not in [
+            "BARTLETT",
+            "BLACKMAN",
+            "BLACKMANHARRIS",
+            "HAMMING",
+            "HANN",
+            "KAISER",
+            "RECTANGULAR",
+        ]:
             raise PyAnsysSoundException(
                 "Window type is invalid. Options are 'BARTLETT', 'BLACKMAN', 'BLACKMANHARRIS', "
                 "'HAMMING', 'HANN', 'KAISER', and 'RECTANGULAR'."

--- a/src/ansys/sound/core/spectrogram_processing/stft.py
+++ b/src/ansys/sound/core/spectrogram_processing/stft.py
@@ -127,18 +127,18 @@ class Stft(SpectrogramProcessingParent):
     @window_type.setter
     def window_type(self, window_type):
         """Set the window type."""
-        if (
-            window_type != "BLACKMANHARRIS"
-            and window_type != "HANN"
-            and window_type != "HAMMING"
-            and window_type != "HANNING"
-            and window_type != "KAISER"
-            and window_type != "BARTLETT"
-            and window_type != "RECTANGULAR"
-        ):
+        if window_type not in [
+            "BARTLETT",
+            "BLACKMAN",
+            "BLACKMANHARRIS",
+            "HAMMING",
+            "HANN",
+            "KAISER",
+            "RECTANGULAR",
+        ]:
             raise PyAnsysSoundException(
                 "Window type is invalid. Options are 'BARTLETT', 'BLACKMAN', 'BLACKMANHARRIS', "
-                "'HAMMING', 'HANN', 'HANNING', 'KAISER', and 'RECTANGULAR'."
+                "'HAMMING', 'HANN', 'KAISER', and 'RECTANGULAR'."
             )
 
         self.__window_type = window_type

--- a/tests/tests_spectrogram_processing/test_spectrogram_processing_stft.py
+++ b/tests/tests_spectrogram_processing/test_spectrogram_processing_stft.py
@@ -161,7 +161,7 @@ def test_stft_set_get_window_type(dpf_sound_test_server):
     assert (
         str(excinfo.value)
         == "Window type is invalid. Options are 'BARTLETT', 'BLACKMAN', 'BLACKMANHARRIS', "
-        "'HAMMING', 'HANN', 'HANNING', 'KAISER', and 'RECTANGULAR'."
+        "'HAMMING', 'HANN', 'KAISER', and 'RECTANGULAR'."
     )
 
     stft.window_type = "KAISER"


### PR DESCRIPTION
Added BLACKMAN as an accepted window type in classes PowerSpectralDensity and Stft, in accordance with the returned error message in case of invalid type.

Also removed HANNING from accepted window types in class Stft, for the sake of consistence with class PowerSpectralDensity