### PR TITLE
docs: add user_agent to check Ansys links

### DIFF
--- a/doc/changelog.d/112.documentation.md
+++ b/doc/changelog.d/112.documentation.md
@@ -1,0 +1,1 @@
+docs: add user_agent to check Ansys links

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -135,6 +135,8 @@ exclude_patterns = [
     "*convert_fields_container_to_np_array.rst",
 ]
 
+# User agent
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36 Edg/123.0.2420.81"  # noqa: E501
 
 # static path
 html_static_path = ["_static"]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -136,7 +136,7 @@ exclude_patterns = [
 ]
 
 # User agent
-user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36 Edg/123.0.2420.81"  # noqa: E501
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.2739.63"  # noqa: E501
 
 # static path
 html_static_path = ["_static"]


### PR DESCRIPTION
@a-bouth While testing in #111 I noticed the following in CICD logging

![image](https://github.com/user-attachments/assets/57bb23f4-bca5-4cf0-975f-ceff1e71c187)

This should be related to the fact that Ansys prevents "bots" from accessing its urls. This PR provide a way to "define" Sphinx as an actual user and not a bot.
Another work around would be to ignore Ansys links but you wouldn't see if a link is broken.