### PR TITLE
DOCS: Remove health check ignore

### DIFF
--- a/doc/changelog.d/139.documentation.md
+++ b/doc/changelog.d/139.documentation.md
@@ -1,0 +1,1 @@
+DOCS: Remove health check ignore

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -138,11 +138,6 @@ exclude_patterns = [
 # User agent
 user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.2739.63"  # noqa: E501
 
-linkcheck_ignore = [
-    "https://download.ansys.com/*",
-    "https://www.ansys.com/*",
-]
-
 # static path
 html_static_path = ["_static"]
 


### PR DESCRIPTION
Previously corporate URLs couldn't be checked even after setting an user agent. This seem to be fixed and working back.

For example, the following command is working for me `curl https://www.ansys.com -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.2739.63"`.