### PR TITLE
docs: fix extra ``:`` in API doc and add ``favicon`` in ``conf.py``

### DIFF
--- a/doc/changelog.d/164.documentation.md
+++ b/doc/changelog.d/164.documentation.md
@@ -1,0 +1,1 @@
+docs: fix extra ``:`` in API doc and add ``favicon`` in ``conf.py``

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -106,9 +106,6 @@ intersphinx_mapping = {
 numpydoc_show_class_members = False
 numpydoc_xref_param_type = True
 
-# autodoc configuration
-autoclass_content = "both"
-
 # Consider enabling numpydoc validation. See:
 # https://numpydoc.readthedocs.io/en/latest/validation.html#
 numpydoc_validate = True

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 import os
 
-from ansys_sphinx_theme import get_version_match
+from ansys_sphinx_theme import ansys_favicon, get_version_match
 from ansys_sphinx_theme import pyansys_logo_black as logo
 import numpy as np
 import pyvista
@@ -29,23 +29,32 @@ copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
 author = "ANSYS, Inc."
 release = version = __version__
 cname = os.getenv("DOCUMENTATION_CNAME", "sound.docs.pyansys.com")
+switcher_version = get_version_match(__version__)
+
+REPOSITORY_NAME = "pyansys-sound"
+USERNAME = "ansys"
+BRANCH = "main"
 
 # Select desired logo, theme, and declare the html title
 html_logo = logo
 html_theme = "ansys_sphinx_theme"
 html_short_title = html_title = "PyAnsys Sound"
 
+# Favicon
+html_favicon = ansys_favicon
+
 # specify the location of your github repo
 html_theme_options = {
-    "github_url": "https://github.com/ansys/pyansys-sound",
+    "github_url": f"https://github.com/{USERNAME}/{REPOSITORY_NAME}",
     "show_prev_next": False,
     "show_breadcrumbs": True,
+    "collapse_navigation": True,
     "additional_breadcrumbs": [
         ("PyAnsys", "https://docs.pyansys.com/"),
     ],
     "switcher": {
         "json_url": f"https://{cname}/versions.json",
-        "version_match": get_version_match(__version__),
+        "version_match": switcher_version,
     },
     "check_switcher": False,
     "static_search": {
@@ -55,17 +64,26 @@ html_theme_options = {
     },
 }
 
+html_context = {
+    "display_github": True,  # Integrate GitHub
+    "github_user": USERNAME,
+    "github_repo": REPOSITORY_NAME,
+    "github_version": BRANCH,
+    "doc_path": "doc/source",
+}
+
 # Sphinx extensions
 extensions = [
+    "jupyter_sphinx",
+    "numpydoc",
+    "sphinx_autodoc_typehints",
+    "sphinx_copybutton",
+    "sphinx_design",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
-    "numpydoc",
+    "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
-    "sphinx_copybutton",
-    "sphinx.ext.napoleon",
-    "sphinx_autodoc_typehints",
-    "sphinx_gallery.gen_gallery",
-    "sphinx_design",
+    # "sphinx_gallery.gen_gallery",
     "pyvista.ext.viewer_directive",
 ]
 
@@ -87,6 +105,9 @@ intersphinx_mapping = {
 # numpydoc configuration
 numpydoc_show_class_members = False
 numpydoc_xref_param_type = True
+
+# autodoc configuration
+autoclass_content = 'both'
 
 # Consider enabling numpydoc validation. See:
 # https://numpydoc.readthedocs.io/en/latest/validation.html#
@@ -159,6 +180,9 @@ source_suffix = ".rst"
 
 # The master toctree document.
 master_doc = "index"
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = "sphinx"
 
 # -- Options for LaTeX output ------------------------------------------------
 latex_elements = {}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -107,7 +107,7 @@ numpydoc_show_class_members = False
 numpydoc_xref_param_type = True
 
 # autodoc configuration
-autoclass_content = 'both'
+autoclass_content = "both"
 
 # Consider enabling numpydoc validation. See:
 # https://numpydoc.readthedocs.io/en/latest/validation.html#

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -83,7 +83,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
-    # "sphinx_gallery.gen_gallery",
+    "sphinx_gallery.gen_gallery",
     "pyvista.ext.viewer_directive",
 ]
 

--- a/src/ansys/sound/core/examples_helpers/_get_example_files.py
+++ b/src/ansys/sound/core/examples_helpers/_get_example_files.py
@@ -165,7 +165,7 @@ def _get_absolute_path(filename: str) -> str:
 
     Parameters
     ----------
-    filename: str
+    filename : str
         Name of the WAV file to get the absolute path for.
 
     Returns

--- a/src/ansys/sound/core/psychoacoustics/_psychoacoustics_parent.py
+++ b/src/ansys/sound/core/psychoacoustics/_psychoacoustics_parent.py
@@ -51,12 +51,12 @@ class PsychoacousticsParent(PyAnsysSound):
 
         Parameters
         ----------
-        bark_band_indexes: numpy array
+        bark_band_indexes : numpy.array
             Array of Bark band indexes to convert in Bark.
 
         Returns
         -------
-        numpy array
+        numpy.array
             Array of corresponding frequencies in Hz.
         """
         for ibark in range(len(bark_band_indexes)):
@@ -79,7 +79,7 @@ class PsychoacousticsParent(PyAnsysSound):
 
         Parameters
         ----------
-        channel_index: int
+        channel_index : int
             Index of the signal channel to check.
 
         Returns

--- a/src/ansys/sound/core/psychoacoustics/fluctuation_strength.py
+++ b/src/ansys/sound/core/psychoacoustics/fluctuation_strength.py
@@ -50,7 +50,7 @@ class FluctuationStrength(PsychoacousticsParent):
 
         Parameters
         ----------
-        signal: Field | FieldsContainer
+        signal : Field | FieldsContainer
             Signal in Pa to compute fluctuation strength on as a DPF field or fields
             container.
         """
@@ -69,7 +69,7 @@ class FluctuationStrength(PsychoacousticsParent):
 
         Parameters
         ----------
-        signal: FieldsContainer | Field
+        signal : FieldsContainer | Field
             Signal in Pa to compute fluctuation strength on as a DPF field or
             fields container.
 
@@ -167,7 +167,7 @@ class FluctuationStrength(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to return the specified output for.
 
         Returns
@@ -185,7 +185,7 @@ class FluctuationStrength(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the specified output for.
 
         Returns
@@ -281,9 +281,9 @@ class FluctuationStrength(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int
+        channel_index : int
             Index of the signal channel to get the specified output for.
-        output_id: str
+        output_id : str
             ID of the specific output parameter to return. Options are:
 
             - ``"total"``: For overall fluctuation strength value in vacil

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
@@ -48,7 +48,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
 
         Parameters
         ----------
-        signal: Field | FieldsContainer
+        signal : Field | FieldsContainer
             Signal in Pa to compute loudness on as a DPF field or fields container.
         """
         super().__init__()
@@ -66,7 +66,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
 
         Parameters
         ----------
-        signal: FieldsContainer | Field
+        signal : FieldsContainer | Field
             Signal in Pa to compute loudness on as a DPF field or fields container.
 
         """
@@ -168,7 +168,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the specified output for.
 
         Returns
@@ -185,7 +185,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the specified output for.
 
         Returns
@@ -202,7 +202,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the specified output for.
 
         Returns
@@ -298,9 +298,9 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int
+        channel_index : int
             Index of the signal channel to get the specified output for.
-        output_id: str
+        output_id : str
             ID of the specific output parameter to return. Options are:
 
             - ``"sone"``: For overall loudness value in sone

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
@@ -168,7 +168,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default 0
+        channel_index: int, default: 0
             Index of the signal channel to get the specified output for.
 
         Returns

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_time_varying.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_time_varying.py
@@ -44,7 +44,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
 
         Parameters
         ----------
-        signal: Field | FieldsContainer
+        signal : Field | FieldsContainer
             Signal to compute time-varying ISO532-1 loudness on as a DPF field or fields
             container.
         """
@@ -63,7 +63,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
 
         Parameters
         ----------
-        signal: FieldsContainer | Field
+        signal : FieldsContainer | Field
             Signal in Pa to compute loudness on as a DPF field or fields container.
         """
         self.__signal = signal
@@ -190,7 +190,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get time-varying loudness for.
 
         Returns
@@ -220,7 +220,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the N5 indicator for.
 
         Returns
@@ -246,7 +246,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the N10 indicator for.
 
         Returns
@@ -269,7 +269,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the time-varying loudness level for.
 
         Returns
@@ -299,7 +299,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the L5 indicator for.
 
         Returns
@@ -325,7 +325,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the L10 indicator for.
 
         Returns

--- a/src/ansys/sound/core/psychoacoustics/prominence_ratio.py
+++ b/src/ansys/sound/core/psychoacoustics/prominence_ratio.py
@@ -45,7 +45,7 @@ class ProminenceRatio(PsychoacousticsParent):
 
         Parameters
         ----------
-        psd: Field
+        psd : Field
             PSD of the signal to compute PR on as a DPF field.
             The PSD field has the following characteristics:
 
@@ -59,7 +59,7 @@ class ProminenceRatio(PsychoacousticsParent):
             You can use the ``ansys.dpf.core.fields_factory.create_scalar_field()`` function
             to create the field.
 
-        frequency_list: list, default: None
+        frequency_list : list, default: None
             List of the frequencies in Hz of the tones (peaks in the spectrum)
             to calculate the PR on. The default is ``None``, in which case a peak
             detection method is applied to automatically find the tones in the input
@@ -81,7 +81,7 @@ class ProminenceRatio(PsychoacousticsParent):
 
         Parameters
         -------
-        psd: Field
+        psd : Field
             PSD of the signal to compute PR on as a DPF field.
 
             The PSD field has the following characteristics:
@@ -120,7 +120,7 @@ class ProminenceRatio(PsychoacousticsParent):
 
         Parameters
         -------
-        frequency_list: list
+        frequency_list : list
             List of the frequencies in Hz of the tones (peaks in the spectrum) to
             calculate the PR for. If this parameter is empty (not specified), a peak
             detection method is applied to automatically find the tones in the input
@@ -317,7 +317,7 @@ class ProminenceRatio(PsychoacousticsParent):
 
         Parameters
         ----------
-        tone_index: int
+        tone_index : int
             Index of the tone.
 
         Returns

--- a/src/ansys/sound/core/psychoacoustics/roughness.py
+++ b/src/ansys/sound/core/psychoacoustics/roughness.py
@@ -47,7 +47,7 @@ class Roughness(PsychoacousticsParent):
 
         Parameters
         ----------
-        signal: Field | FieldsContainer
+        signal : Field | FieldsContainer
             Signal in Pa to compute roughness on as a DPF field or fields container.
         """
         super().__init__()
@@ -65,7 +65,7 @@ class Roughness(PsychoacousticsParent):
 
         Parameters
         ----------
-        signal: Field | FieldsContainer
+        signal : Field | FieldsContainer
             Signal in Pa to compute roughness on as a DPF field or fields container.
 
         """
@@ -159,7 +159,7 @@ class Roughness(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the specified output for.
 
         Returns
@@ -176,7 +176,7 @@ class Roughness(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the specified output for.
 
         Returns
@@ -272,7 +272,7 @@ class Roughness(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int
+        channel_index : int
             Index of the signal channel to get the specified output for.
         output_id: str
             ID of the specific output parameter to return. Options are:

--- a/src/ansys/sound/core/psychoacoustics/sharpness.py
+++ b/src/ansys/sound/core/psychoacoustics/sharpness.py
@@ -39,7 +39,7 @@ class Sharpness(PsychoacousticsParent):
 
         Parameters
         ----------
-        signal: Field | FieldsContainer
+        signal : Field | FieldsContainer
             Signal in Pa to compute sharpness on as a DPF field or fields container.
         """
         super().__init__()
@@ -57,7 +57,7 @@ class Sharpness(PsychoacousticsParent):
 
         Parameters
         -------
-        signal: Field | FieldsContainer
+        signal : Field | FieldsContainer
             Signal in Pa to compute sharpness on as a DPF field or fields container.
 
         """
@@ -139,7 +139,7 @@ class Sharpness(PsychoacousticsParent):
 
         Parameters
         ----------
-        channel_index: int, default: 0
+        channel_index : int, default: 0
             Index of the signal channel to get the sharpness value for.
 
         Returns

--- a/src/ansys/sound/core/psychoacoustics/spectral_centroid.py
+++ b/src/ansys/sound/core/psychoacoustics/spectral_centroid.py
@@ -39,7 +39,7 @@ class SpectralCentroid(PsychoacousticsParent):
 
         Parameters
         ----------
-        signal: Field
+        signal : Field
             Signal to compute spectral centroid on as a DPF field.
         """
         super().__init__()
@@ -57,7 +57,7 @@ class SpectralCentroid(PsychoacousticsParent):
 
         Parameters
         -------
-        signal: Field
+        signal : Field
             Signal to compute spectral centroid on as a DPF field.
         """
         self.__signal = signal

--- a/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio.py
+++ b/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio.py
@@ -45,7 +45,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
 
         Parameters
         ----------
-        psd: Field
+        psd : Field
             PSD of the signal to compute TNR on as a DPF field.
             The PSD field has the following characteristics:
 
@@ -59,7 +59,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
             You can use the ``ansys.dpf.core.fields_factory.create_scalar_field()`` function
             to create the field.
 
-        frequency_list: list, default: None
+        frequency_list : list, default: None
             List of the frequencies in Hz of the tones (peaks in the spectrum) for which
             to calculate the TNR. The default is ``None``, in which case a peak detection
             method is applied to automatically find the tones in the input spectrum. Then,
@@ -81,7 +81,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
 
         Parameters
         -------
-        psd: Field
+        psd : Field
             PSD of the signal to compute TNR on as a DPF field.
             The PSD field has the following characteristics:
 
@@ -119,7 +119,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
 
         Parameters
         -------
-        frequency_list: list
+        frequency_list : list
             List of the frequencies in Hz of the tones (peaks in the spectrum)
             to calculate the TNR on. If this input is empty (not specified), a peak
             detection method is applied to automatically find the tones in the input
@@ -311,7 +311,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
 
         Parameters
         ----------
-        tone_index: int
+        tone_index : int
             Index of the tone.
 
         Returns

--- a/src/ansys/sound/core/server_helpers/_connect_to_or_start_server.py
+++ b/src/ansys/sound/core/server_helpers/_connect_to_or_start_server.py
@@ -49,14 +49,14 @@ def connect_to_or_start_server(
 
     Parameters
     ----------
-    port: str, default: None
+    port : str, default: None
         Port that the DPF server is listening on.
-    ip: str, default: None
+    ip : str, default: None
         IP address for the DPF server.
-    ansys_path: str, default: None
+    ansys_path : str, default: None
         Root path for the Ansys installation. For example, ``C:\\Program Files\\ANSYS Inc\\v242``.
         This parameter is ignored if either the port or IP address is set.
-    use_license_context: bool, default: False
+    use_license_context : bool, default: False
         Whether to check out the DPF Sound license increment (``avrxp_snd_level1``) before using
         PyAnsys Sound. Checking out the license increment improves performance if you are doing
         multiple calls to DPF Sound operators because they require licensing. This parameter

--- a/src/ansys/sound/core/signal_utilities/apply_gain.py
+++ b/src/ansys/sound/core/signal_utilities/apply_gain.py
@@ -41,12 +41,12 @@ class ApplyGain(SignalUtilitiesParent):
 
         Parameters
         ----------
-        signal: Field | FieldsContainer, default: None
+        signal : Field | FieldsContainer, default: None
             Signals to apply gain on as a DPF field or fields container.
-        gain: float, default: 0.0
+        gain : float, default: 0.0
             Gain value in decibels (dB) or linear unit. By default, gain is specified in decibels.
             However, you can use the next parameter to change to a linear unit.
-        gain_in_db: bool, default: True
+        gain_in_db : bool, default: True
             Whether gain is in dB. When ``False``, gain is in a linear unit.
         """
         super().__init__()
@@ -87,7 +87,7 @@ class ApplyGain(SignalUtilitiesParent):
 
         Parameters
         ----------
-        new_gain:
+        new_gain : float
             New gain value.
         """
         self.__gain = new_gain
@@ -114,7 +114,7 @@ class ApplyGain(SignalUtilitiesParent):
 
         Parameters
         ----------
-        new_gain_in_db:
+        new_gain_in_db : bool
             Whether to set the new gain in decibels(dB). When ``False``, gain is
             set in a linear unit.
         """

--- a/src/ansys/sound/core/signal_utilities/create_sound_field.py
+++ b/src/ansys/sound/core/signal_utilities/create_sound_field.py
@@ -47,11 +47,11 @@ class CreateSoundField(SignalUtilitiesParent):
 
         Parameters
         ----------
-        data:
+        data : np.array, default: np.empty(0)
             Data to use to create the PyAnsys Sound field as a 1D NumPy array.
-        sampling_frequency: float, default: 44100.0
+        sampling_frequency : float, default: 44100.0
             Sampling frequency of the data.
-        unit: str, default: "Pa"
+        unit : str, default: "Pa"
             Unit of the data.
         """
         super().__init__()
@@ -92,7 +92,7 @@ class CreateSoundField(SignalUtilitiesParent):
 
         Parameters
         ----------
-        new_unit: str
+        new_unit : str
             New unit as a string.
         """
         self.__unit = new_unit
@@ -119,7 +119,7 @@ class CreateSoundField(SignalUtilitiesParent):
 
         Parameters
         ----------
-        new_sampling_frequency: float
+        new_sampling_frequency : float
             New sampling frequency in Hz.
         """
         if new_sampling_frequency < 0.0:

--- a/src/ansys/sound/core/signal_utilities/crop_signal.py
+++ b/src/ansys/sound/core/signal_utilities/crop_signal.py
@@ -40,11 +40,11 @@ class CropSignal(SignalUtilitiesParent):
 
         Parameters
         ----------
-        signal: FieldsContainer | Field, default: None
+        signal : FieldsContainer | Field, default: None
             Signal to resample as a DPF field or fields container.
-        start_time: float, default: 0.0
+        start_time : float, default: 0.0
             Start time of the part to crop in seconds.
-        end_time: float, default: 0.0
+        end_time : float, default: 0.0
             End time of the part to crop in seconds.
         """
         super().__init__()
@@ -64,7 +64,7 @@ class CropSignal(SignalUtilitiesParent):
 
         Parameters
         ----------
-        new_start:
+        new_start : float
             New start time in seconds.
         """
         if new_start < 0.0:
@@ -88,12 +88,12 @@ class CropSignal(SignalUtilitiesParent):
         return self.__end_time  # pragma: no cover
 
     @end_time.setter
-    def end_time(self, new_end: bool):
+    def end_time(self, new_end: float):
         """Set a new end time.
 
         Parameters
         ----------
-        new_end:
+        new_end : float
             New end time in seconds.
         """
         if new_end < 0.0:

--- a/src/ansys/sound/core/signal_utilities/load_wav.py
+++ b/src/ansys/sound/core/signal_utilities/load_wav.py
@@ -39,7 +39,7 @@ class LoadWav(SignalUtilitiesParent):
 
         Parameters
         ----------
-        path_to_wav: str, default: ""
+        path_to_wav : str, default: ""
             Path to the WAV file to load. The path can be set during the instantiation
             of the object or with the ``LoadWav.set_path()`` method.
         """
@@ -58,7 +58,7 @@ class LoadWav(SignalUtilitiesParent):
 
         Parameters
         ----------
-        path_to_wav: str
+        path_to_wav : str
             Path to the WAV file.
         """
         self.__path_to_wav = path_to_wav

--- a/src/ansys/sound/core/signal_utilities/resample.py
+++ b/src/ansys/sound/core/signal_utilities/resample.py
@@ -41,9 +41,9 @@ class Resample(SignalUtilitiesParent):
 
         Parameters
         ----------
-        signal: Field | FieldsContainer, default: None
+        signal : Field | FieldsContainer, default: None
             Signal to resample as a DPF field or fields container.
-        new_sampling_frequency: float, default: 44100.0
+        new_sampling_frequency : float, default: 44100.0
             New sampling frequency to use.
         """
         super().__init__()
@@ -62,7 +62,7 @@ class Resample(SignalUtilitiesParent):
 
         Parameters
         ----------
-        new_sampling_frequency: float
+        new_sampling_frequency : float
             New sampling frequency.
         """
         if new_sampling_frequency < 0.0:

--- a/src/ansys/sound/core/signal_utilities/sum_signals.py
+++ b/src/ansys/sound/core/signal_utilities/sum_signals.py
@@ -38,7 +38,7 @@ class SumSignals(SignalUtilitiesParent):
 
         Parameters
         ----------
-        signals: FieldsContainer, default: None
+        signals : FieldsContainer, default: None
             Input signals to sum. Each field of the signal is summed.
         """
         super().__init__()

--- a/src/ansys/sound/core/signal_utilities/write_wav.py
+++ b/src/ansys/sound/core/signal_utilities/write_wav.py
@@ -40,12 +40,12 @@ class WriteWav(SignalUtilitiesParent):
 
         Parameters
         ----------
-        signal: FieldsContainer, default: None
+        signal : FieldsContainer, default: None
             Signal to write to a WAV file. Each channel in the DPF fields container is a field.
-        path_to_write: str, default: ''
+        path_to_write : str, default: ''
             Path for the WAV file. This parameter can be set during the instantiation
             of the object or with the ``LoadWav.set_path()`` method.
-        bit_depth: str, default: 'float32'
+        bit_depth : str, default: 'float32'
             Bit depth. Options are ``'float32'``, ``'int32'``, ``'int16'``, and ``'int8'``.
             This means that the samples are respectively coded into the WAV file
             using 32 bits (32-bit IEEE Float), 32 bits (int), 16 bits (int), or 8 bits (int).

--- a/src/ansys/sound/core/signal_utilities/zero_pad.py
+++ b/src/ansys/sound/core/signal_utilities/zero_pad.py
@@ -38,9 +38,9 @@ class ZeroPad(SignalUtilitiesParent):
 
         Parameters
         ----------
-        signal: Field | FieldsContainer, default: None
+        signal : Field | FieldsContainer, default: None
             Signal to add zeros to the end of as a DPF field or fields container.
-        duration_zeros: float: default: 0.0
+        duration_zeros : float: default: 0.0
             Duration in seconds of the zeros to append to the input signal.
         """
         super().__init__()
@@ -80,7 +80,7 @@ class ZeroPad(SignalUtilitiesParent):
 
         Parameters
         ----------
-        new_duration_zeros: float
+        new_duration_zeros : float
             New duration for the zero padding in seconds.
         """
         if new_duration_zeros < 0.0:

--- a/src/ansys/sound/core/sound_composer/source_control_spectrum.py
+++ b/src/ansys/sound/core/sound_composer/source_control_spectrum.py
@@ -38,9 +38,9 @@ class SourceControlSpectrum(SourceControlParent):
 
         Parameters
         ----------
-        duration : float, default 0.0
+        duration: float, default: 0.0
             Duration of the sound generated from the spectrum source, in seconds.
-        method : int, default 1
+        method: int, default: 1
             Sound generation method to be used. 1 for IFFT, 2 for Hybrid.
         """
         super().__init__()

--- a/src/ansys/sound/core/sound_composer/source_control_spectrum.py
+++ b/src/ansys/sound/core/sound_composer/source_control_spectrum.py
@@ -38,9 +38,9 @@ class SourceControlSpectrum(SourceControlParent):
 
         Parameters
         ----------
-        duration: float, default: 0.0
+        duration : float, default: 0.0
             Duration of the sound generated from the spectrum source, in seconds.
-        method: int, default: 1
+        method : int, default: 1
             Sound generation method to be used. 1 for IFFT, 2 for Hybrid.
         """
         super().__init__()

--- a/src/ansys/sound/core/sound_power/sound_power_level_iso_3744.py
+++ b/src/ansys/sound/core/sound_power/sound_power_level_iso_3744.py
@@ -54,21 +54,21 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         Parameters
         ----------
-        surface_shape: str, default: 'Hemisphere'
+        surface_shape : str, default: 'Hemisphere'
             Shape of measurement surface. Available options are 'Hemisphere' (default) and
             'Half-hemisphere'.
-        surface_radius: float, default: 1
+        surface_radius : float, default: 1
             Radius in m of the hemisphere or half-hemisphere measurement surface.
             By default, 1 meter.
-        K1: float, default: 0
+        K1 : float, default: 0
             Background noise correction K1 in dB (section 8.2.3 of ISO 3744).
             By default, 0 dB.
-        K2: float, default: 0
+        K2 : float, default: 0
             Environmental correction K2 in dB (Annex A of ISO 3744). By default, 0 dB.
-        C1: float, default: 0
+        C1 : float, default: 0
             Meteorological reference quantity correction C1 in dB (Annex G of ISO 3744).
             By default, 0 dB.
-        C2: float, default: 0
+        C2 : float, default: 0
             Meteorological radiation impedance correction C2 in dB (Annex G of ISO 3744).
             By default, 0 dB.
         """
@@ -188,7 +188,7 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         Parameters
         ----------
-        signal: Field
+        signal : Field
             Recorded signal in Pa from one specific position.
         """
         if type(signal) is not Field:
@@ -203,7 +203,7 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         Parameters
         ----------
-        index: int
+        index : int
             Signal index.
 
         Returns
@@ -223,7 +223,7 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         Parameters
         ----------
-        index: int
+        index : int
             Signal index.
         """
         if index > len(self.__signals) - 1:
@@ -257,20 +257,20 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         Parameters
         ----------
-            length: float
-                Measurement room length in m.
-            width: float
-                Measurement room width in m.
-            height: float
-                Measurement room height in m.
-            alpha: float
-                Mean sound absorption coefficient between 0 and 1. Typical example values are
-                given in Table A.1 of ISO 3744.
+        length : float
+            Measurement room length in m.
+        width : float
+            Measurement room width in m.
+        height : float
+            Measurement room height in m.
+        alpha : float
+            Mean sound absorption coefficient between 0 and 1. Typical example values are
+            given in Table A.1 of ISO 3744.
 
         Returns
         -------
-            float
-                Calculated correction K2 in dB
+        float
+            Calculated correction K2 in dB
         """
         if length <= 0.0 or width <= 0.0 or height <= 0.0:
             raise PyAnsysSoundException(
@@ -305,9 +305,9 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         Parameters
         ----------
-        pressure: float, default: 101.325
+        pressure : float, default: 101.325
             Static pressure in kPa.
-        temperature: float, default: 23.0
+        temperature : float, default: 23.0
             Temperature in °C.
 
         Returns
@@ -335,8 +335,8 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         Parameters
         ----------
-            filename: string
-                Sound power level project file.
+        filename: string
+            Sound power level project file.
         """
         # Set operator inputs.
         self.__operator_load.connect(0, filename)

--- a/src/ansys/sound/core/spectral_processing/power_spectral_density.py
+++ b/src/ansys/sound/core/spectral_processing/power_spectral_density.py
@@ -65,7 +65,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
             Window type used for the PSD computation. Options are ``'BARTLETT'``, ``'BLACKMAN'``,
             ``'BLACKMANHARRIS'``,``'HAMMING'``, ``'HANN'``, ``'KAISER'``, and
             ``'RECTANGULAR'``.
-        window_length : int, default: 2048
+        window_length: int, default: 2048
             Number of points of the window used for the PSD computation , by default 2048.
         overlap: float, default: 0.25
             Overlap value between two successive segments where the FFT is computed.
@@ -242,7 +242,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
 
         Parameters
         ----------
-        ref_value : float, default: 1.0
+        ref_value: float, default: 1.0
             Reference value for dB level calculation, by default 1.0. Example: ref_value = 2e-5 Pa
             for sound pressure level (dBSPL/Hz).
 
@@ -278,7 +278,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
 
         Parameters
         ----------
-        ref_value : float, default: 1.0
+        ref_value: float, default: 1.0
             Reference value for dB level calculation, by default 1.0. Example: ref_value = 2e-5 Pa
             for sound pressure level (dBSPL/Hz).
 
@@ -306,7 +306,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
 
         Parameters
         ----------
-        display_in_dB : bool, default: False
+        display_in_dB: bool, default: False
             Parameter that specifies whether the PSD should be plotted in dB/Hz (True)
             or unit^2/Hz (False).
         """

--- a/src/ansys/sound/core/spectral_processing/power_spectral_density.py
+++ b/src/ansys/sound/core/spectral_processing/power_spectral_density.py
@@ -56,18 +56,18 @@ class PowerSpectralDensity(SpectralProcessingParent):
 
         Parameters
         ----------
-        signal: Field
+        signal : Field
             Mono signal as a DPF field on which to compute the PSD.
-        fft_size: int, default: 2048
+        fft_size : int, default: 2048
             Number of FFT points to use for the PSD estimate.
             Use a power of 2 for better performance.
-        window_type: str, default: 'HANN'
+        window_type : str, default: 'HANN'
             Window type used for the PSD computation. Options are ``'BARTLETT'``, ``'BLACKMAN'``,
             ``'BLACKMANHARRIS'``,``'HAMMING'``, ``'HANN'``, ``'KAISER'``, and
             ``'RECTANGULAR'``.
-        window_length: int, default: 2048
+        window_length : int, default: 2048
             Number of points of the window used for the PSD computation , by default 2048.
-        overlap: float, default: 0.25
+        overlap : float, default: 0.25
             Overlap value between two successive segments where the FFT is computed.
             Values range from 0 to 1. For example, ``0`` means no overlap,
             and ``0.5`` means 50% overlap.
@@ -242,7 +242,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
 
         Parameters
         ----------
-        ref_value: float, default: 1.0
+        ref_value : float, default: 1.0
             Reference value for dB level calculation, by default 1.0. Example: ref_value = 2e-5 Pa
             for sound pressure level (dBSPL/Hz).
 
@@ -278,7 +278,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
 
         Parameters
         ----------
-        ref_value: float, default: 1.0
+        ref_value : float, default: 1.0
             Reference value for dB level calculation, by default 1.0. Example: ref_value = 2e-5 Pa
             for sound pressure level (dBSPL/Hz).
 
@@ -306,7 +306,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
 
         Parameters
         ----------
-        display_in_dB: bool, default: False
+        display_in_dB : bool, default: False
             Parameter that specifies whether the PSD should be plotted in dB/Hz (True)
             or unit^2/Hz (False).
         """

--- a/src/ansys/sound/core/spectrogram_processing/isolate_orders.py
+++ b/src/ansys/sound/core/spectrogram_processing/isolate_orders.py
@@ -52,24 +52,24 @@ class IsolateOrders(SpectrogramProcessingParent):
 
         Parameters
         ----------
-        signal: FieldsContainer | Field, default: None
+        signal : FieldsContainer | Field, default: None
             One or more input signals to isolate orders on as a DPF fields container or field.
-        rpm_profile: Field, default: None
+        rpm_profile : Field, default: None
             RPM signal associated with the time signals as a DPF field.
             It is assumed that the signal's unit is ``rpm``. If this is not the case,
             inaccurate behavior might occur during the conversion from RPM to frequency.
-        orders: list, default: None
+        orders : list, default: None
             List of the order numbers to isolate. The list must contain at least one value.
-        fft_size: int, default: 1024
+        fft_size : int, default: 1024
             Size of the FFT used to compute the STFT.
-        window_type: str, default: 'HANN'
+        window_type : str, default: 'HANN'
             Window type used for the FFT computation. Options are ``'BARTLETT'``, ``'BLACKMAN'``,
             ``'BLACKMANHARRIS'``,``'HAMMING'``, ``'HANN'``, ``'HANNING'``, ``'KAISER'``, and
             ``'RECTANGULAR'``.
-        window_overlap: float, default: 0.5
+        window_overlap : float, default: 0.5
             Overlap value between two successive FFT computations. Values can range from 0 to 1.
             For example, ``0`` means no overlap, and ``0.5`` means 50% overlap.
-        width_selection: int, default: 10
+        width_selection : int, default: 10
             Width in Hz of the area used to select each individual order.
             Note that its precision depends on the FFT size.
         """

--- a/src/ansys/sound/core/spectrogram_processing/istft.py
+++ b/src/ansys/sound/core/spectrogram_processing/istft.py
@@ -41,7 +41,7 @@ class Istft(SpectrogramProcessingParent):
 
         Parameters
         ----------
-        stft: FieldsContainer, default: None
+        stft : FieldsContainer, default: None
             DPF fields container containing a short-time Fourier transform (STFT)
             computed with the ``Stft`` class.
         """

--- a/src/ansys/sound/core/spectrogram_processing/stft.py
+++ b/src/ansys/sound/core/spectrogram_processing/stft.py
@@ -47,16 +47,16 @@ class Stft(SpectrogramProcessingParent):
 
         Parameters
         ----------
-        signal: Field | FieldsContainer, default: None
+        signal : Field | FieldsContainer, default: None
             Mono signal to compute the STFT on as a DPF field or fields container.
-        fft_size: int, default: 2048
+        fft_size : int, default: 2048
             Size (as an integer) of the FFT to compute the STFT.
             Use a power of 2 for better performance.
-        window_type: str, default: 'HANN'
+        window_type : str, default: 'HANN'
             Window type used for the FFT computation. Options are ``'BARTLETT'``, ``'BLACKMAN'``,
             ``'BLACKMANHARRIS'``,``'HAMMING'``, ``'HANN'``, ``'KAISER'``, and
             ``'RECTANGULAR'``.
-        window_overlap: float, default: 0.5
+        window_overlap : float, default: 0.5
             Overlap value between two successive FFT computations. Values can range from 0 to 1.
             For example, ``0`` means no overlap, and ``0.5`` means 50% overlap.
         """

--- a/src/ansys/sound/core/xtract/xtract.py
+++ b/src/ansys/sound/core/xtract/xtract.py
@@ -59,16 +59,16 @@ class Xtract(XtractParent):
 
         Parameters
         ----------
-        input_signal: FieldsContainer | Field, default: None
+        input_signal : FieldsContainer | Field, default: None
             One or more signals to apply Xtract processing on as a DPF field or fields container.
-        parameters_denoiser:  XtractDenoiserParameters, default: None
+        parameters_denoiser : XtractDenoiserParameters, default: None
             Structure that contains the parameters of the denoising step:
 
             - Noise PSD (field) is the power spectral density (PSD) of the noise.
 
             This structure is of the ``XtractDenoiserParameters`` type. For more information,
             see this class.
-        parameters_tonal: XtractTonalParameters, default: None
+        parameters_tonal : XtractTonalParameters, default: None
             Structure that contains the parameters of the tonal extraction step:
 
             - NFFT (int) is the number of points used for the FFT computation.
@@ -80,7 +80,7 @@ class Xtract(XtractParent):
 
             This structure is of the ``XtractTonalParameters`` type. For more information,
             see this class.
-        parameters_transient:
+        parameters_transient : XtractTransientParameters, default: None
             Structure that contains the parameters of the transient extraction step:
 
             - Lower threshold (float), which is between 0 and 100 percent.

--- a/src/ansys/sound/core/xtract/xtract_denoiser.py
+++ b/src/ansys/sound/core/xtract/xtract_denoiser.py
@@ -46,11 +46,11 @@ class XtractDenoiser(XtractParent):
 
         Parameters
         ----------
-        input_signal: FieldsContainer | Field, default: None
+        input_signal : FieldsContainer | Field, default: None
             One or more signals to denoise as a DPF fields container or field. When inputting a
             fields container, each signal (each field of the fields container) is processed
             individually.
-        input_parameters: XtractDenoiserParametersm default: None
+        input_parameters : XtractDenoiserParametersm, default: None
             Structure that contains the parameters of the algorithm:
 
             - Noise PSD (Field): Power spectral density of the noise

--- a/src/ansys/sound/core/xtract/xtract_denoiser_parameters.py
+++ b/src/ansys/sound/core/xtract/xtract_denoiser_parameters.py
@@ -39,7 +39,7 @@ class XtractDenoiserParameters(XtractParent):
 
         Parameters
         ----------
-        noise_psd:
+        noise_psd : Field, optional
             Power spectral density of the noise in unit^2/Hz (Pa^2/Hz for example).
             This parameter can be produced using one of the following methods:
 
@@ -96,13 +96,13 @@ class XtractDenoiserParameters(XtractParent):
 
         Parameters
         ----------
-        white_noise_level: float
+        white_noise_level : float
             Power of the white noise  in dB SPL.
-        sampling_frequency: float, optional
+        sampling_frequency : float, optional
             Sampling frequency in Hz of the signal to denoise,
             which can be different from the signal used for creating the noise profile.
             The default is the sampling frequency of the noise signal.
-        window_length: int, default: 50
+        window_length : int, default: 50
             Window length for the noise level estimation in milliseconds (ms).
 
         Returns
@@ -126,13 +126,13 @@ class XtractDenoiserParameters(XtractParent):
 
         Parameters
         ----------
-        signal: Field
+        signal : Field
             Noise signal.
-        sampling_frequency: float, optional
+        sampling_frequency : float, optional
             Sampling frequency in Hz of the signal to denoise,
             which can be different from the signal used for creating the noise profile.
             The default is the sampling frequency of the noise signal.
-        window_length: int, default: 50
+        window_length : int, default: 50
             Window length for the noise level estimation in milliseconds (ms).
 
         Returns
@@ -156,9 +156,9 @@ class XtractDenoiserParameters(XtractParent):
 
         Parameters
         ----------
-        signal: Field
+        signal : Field
             Signal to estimate the noise profile from.
-        window_length: int, default: 50
+        window_length : int, default: 50
             Window length for the noise level estimation in milliseconds (ms).
 
         Returns

--- a/src/ansys/sound/core/xtract/xtract_tonal.py
+++ b/src/ansys/sound/core/xtract/xtract_tonal.py
@@ -46,12 +46,12 @@ class XtractTonal(XtractParent):
 
         Parameters
         ----------
-        input_signal: FieldsContainer | Field, default: None
+        input_signal : FieldsContainer | Field, default: None
             One or more signals to extract tonal components from
             as a DPF field or fields container.
             When inputting a fields container,
             each signal (each field of the fields container) is processed individually.
-        input_parameters:
+        input_parameters : XtractTonalParameters, default: None
             Structure that contains the parameters of the algorithm:
 
             - NFFT (int) is the number of points used for the FFT computation.

--- a/src/ansys/sound/core/xtract/xtract_tonal_parameters.py
+++ b/src/ansys/sound/core/xtract/xtract_tonal_parameters.py
@@ -52,25 +52,25 @@ class XtractTonalParameters(XtractParent):
 
         Parameters
         ----------
-        regularity: float, default: 1.0
+        regularity : float, default: 1.0
             Regularity parameter. Values are between 0 and 1. This parameter is designed to
             reject tonal components with too much frequency variation. You should start with
             the default value (``1.0``) and then lower it to remove detected tonals whose
             frequency evolutions are too erratic.
-        maximum_slope: float, default: 750.0
+        maximum_slope : float, default: 750.0
             Maximum slope in Hz/s for each tonal component. Values are between 0 and 15000 Hz/s.
             A higher value enables finding tonal components with a greater
             frequency slope over time.
-        minimum_duration: float, default: 1.0
+        minimum_duration : float, default: 1.0
             Minimum duration in seconds for each tonal components.
             Values are between 0 and 5.
-        intertonal_gap: float, default: 20.0
+        intertonal_gap : float, default: 20.0
             Minimum gap in Hz between two tonal components.
             Values are between 10 and 200.
-        local_emergence: float, default: 15.0
+        local_emergence : float, default: 15.0
             Emergence of the tonal components compared to the background noise in dB.
             Values are between 0 and 100.
-        fft_size: int, default: 8192
+        fft_size : int, default: 8192
             Number of samples for the FFT computation. The value
             must be greater than 0.
         """

--- a/src/ansys/sound/core/xtract/xtract_transient.py
+++ b/src/ansys/sound/core/xtract/xtract_transient.py
@@ -46,11 +46,11 @@ class XtractTransient(XtractParent):
 
         Parameters
         ----------
-        input_signal: FieldsContainer | Field, default: None
+        input_signal : FieldsContainer | Field, default: None
             One or more signals to extract transient components on
             as a DPF fields container or fields. When inputting a fields container,
             each signal (each field of the fields container) is processed individually.
-        input_parameters: XtractTransientParameters, default: None
+        input_parameters : XtractTransientParameters, default: None
             Structure that contains the parameters of the algorithm:
 
             - Lower threshold (float), which is between 0 and 100.
@@ -90,7 +90,7 @@ class XtractTransient(XtractParent):
 
         Parameters
         ----------
-        value: FieldsContainer | Field
+        value : FieldsContainer | Field
             One or more signal to extract transient components on
             as a DPF fields container or field. When inputting a fields container,
             each signal (each field of the fields container) is processed individually.
@@ -117,7 +117,7 @@ class XtractTransient(XtractParent):
 
         Parameters
         ----------
-        value: XtractTransientParameters
+        value : XtractTransientParameters
             Structure that contains the parameters of the algorithm:
 
             - Lower threshold (float), which is between 0 and 100 percent

--- a/src/ansys/sound/core/xtract/xtract_transient_parameters.py
+++ b/src/ansys/sound/core/xtract/xtract_transient_parameters.py
@@ -40,11 +40,11 @@ class XtractTransientParameters(XtractParent):
 
         Parameters
         ----------
-        lower_threshold: float, default: 0.0
+        lower_threshold : float, default: 0.0
             Minimum threshold, which is related to the minimum energy of transient components.
             Values are between 0 and 100. You should set this parameter as high as possible
             provided that no transient element remains in the remainder (non-transient signal).
-        upper_threshold: float, default: 100.0
+        upper_threshold : float, default: 100.0
             Maximum threshold in dB, which is related to the maximum energy of transient components.
             Values are between 0 and 100. You should set this parameter as low as possible provided
             that no transient element remains in the remainder (non-transient signal).


### PR DESCRIPTION
After investigating the issue related to the extra ``:`` in the API documentation, I found that it was coming from the extension ``sphinx.ext.napoleon``.

How it used to render:
![image](https://github.com/user-attachments/assets/7c5b136c-a6ab-4d59-8974-a4bb92a7c531)


How it renders now:
![image](https://github.com/user-attachments/assets/de8c2fba-c161-4180-8062-896e72a0a86a)