### PR TITLE
ci: deleting docker images from cicd

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -192,6 +192,12 @@ jobs:
               docker rm $dockerContainers
           }
 
+      - name: "Delete the Docker images (and untagged ones)"
+        if: always()
+        run: |
+          docker image rm ghcr.io/ansys/ansys-sound:latest
+          docker system prune -f
+
   doc-build:
     name: "Building library documentation"
     runs-on: [self-hosted, Windows, pyansys-sound]
@@ -255,6 +261,12 @@ jobs:
               docker stop $dockerContainers
               docker rm $dockerContainers
           }
+
+      - name: "Delete the Docker images (and untagged ones)"
+        if: always()
+        run: |
+          docker image rm ghcr.io/ansys/ansys-sound:latest
+          docker system prune -f
 
 # =================================================================================================
 # =================================================================================================

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -265,7 +265,6 @@ jobs:
       - name: "Delete the Docker images (and untagged ones)"
         if: always()
         run: |
-          docker image rm ghcr.io/ansys/ansys-sound:latest
           docker system prune -f
 
 # =================================================================================================

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -195,7 +195,6 @@ jobs:
       - name: "Delete the Docker images (and untagged ones)"
         if: always()
         run: |
-          docker image rm ghcr.io/ansys/ansys-sound:latest
           docker system prune -f
 
   doc-build:

--- a/doc/changelog.d/165.maintenance.md
+++ b/doc/changelog.d/165.maintenance.md
@@ -1,0 +1,1 @@
+ci: deleting docker images from cicd


### PR DESCRIPTION
Docker images need to be cleaned not to overload the VM.
This PR add this step within the CICD.