### PR TITLE
fix: remove unnecessary explicit getters

### DIFF
--- a/doc/changelog.d/166.fixed.md
+++ b/doc/changelog.d/166.fixed.md
@@ -1,0 +1,1 @@
+fix: remove unnecessary explicit getters

--- a/doc/source/api/psychoacoustics.rst
+++ b/doc/source/api/psychoacoustics.rst
@@ -8,6 +8,7 @@ Psychoacoustics
 
     LoudnessISO532_1_Stationary
     LoudnessISO532_1_TimeVarying
+    SpectralCentroid
     Sharpness
     Roughness
     FluctuationStrength

--- a/src/ansys/sound/core/psychoacoustics/fluctuation_strength.py
+++ b/src/ansys/sound/core/psychoacoustics/fluctuation_strength.py
@@ -59,33 +59,14 @@ class FluctuationStrength(PsychoacousticsParent):
         self.__operator = Operator("compute_fluctuation_strength")
 
     @property
-    def signal(self):
-        """Signal property."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> Field | FieldsContainer:
+        """Input sound signal in Pa as a DPF field or fields container."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field | FieldsContainer):
-        """Set the signal.
-
-        Parameters
-        ----------
-        signal : FieldsContainer | Field
-            Signal in Pa to compute fluctuation strength on as a DPF field or
-            fields container.
-
-        """
+        """Set the signal."""
         self.__signal = signal
-
-    @signal.getter
-    def signal(self) -> Field | FieldsContainer:
-        """Input signal.
-
-        Returns
-        -------
-        Field | FieldsContainer
-            Signal in Pa as a DPF field or fields container.
-        """
-        return self.__signal
 
     def process(self):
         """Compute the fluctuation strength.

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
@@ -56,32 +56,14 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
         self.__operator = Operator("compute_loudness_iso532_1")
 
     @property
-    def signal(self):
-        """Signal."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> Field | FieldsContainer:
+        """Input sound signal in Pa as a DPF field or fields container."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field | FieldsContainer):
-        """Set the signal.
-
-        Parameters
-        ----------
-        signal : FieldsContainer | Field
-            Signal in Pa to compute loudness on as a DPF field or fields container.
-
-        """
+        """Set the signal."""
         self.__signal = signal
-
-    @signal.getter
-    def signal(self) -> Field | FieldsContainer:
-        """Signal.
-
-        Returns
-        -------
-        Field | FieldsContainer
-            Signal in Pa as a DPF field or fields container.
-        """
-        return self.__signal
 
     def process(self):
         """Compute the loudness.

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_time_varying.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_time_varying.py
@@ -53,31 +53,14 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
         self.__operator = Operator("compute_loudness_iso532_1_vs_time")
 
     @property
-    def signal(self):
-        """Signal property."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> Field | FieldsContainer:
+        """Input sound signal in Pa as a DPF field or fields container."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field | FieldsContainer):
-        """Set the signal.
-
-        Parameters
-        ----------
-        signal : FieldsContainer | Field
-            Signal in Pa to compute loudness on as a DPF field or fields container.
-        """
+        """Set the signal."""
         self.__signal = signal
-
-    @signal.getter
-    def signal(self) -> Field | FieldsContainer:
-        """Signal.
-
-        Returns
-        -------
-        Field | FieldsContainer
-            Signal as a DPF field or a fields container.
-        """
-        return self.__signal
 
     def process(self):
         """Compute the time-varying ISO532-1 loudness.

--- a/src/ansys/sound/core/psychoacoustics/prominence_ratio.py
+++ b/src/ansys/sound/core/psychoacoustics/prominence_ratio.py
@@ -49,12 +49,12 @@ class ProminenceRatio(PsychoacousticsParent):
             PSD of the signal to compute PR on as a DPF field.
             The PSD field has the following characteristics:
 
-            - num_entities = 1
-            - location = "TimeFreq_sets"
-            - data: Vector of amplitude values in unit^2/Hz
-            - time_freq_support: Vector of regularly spaced frequencies in Hz associated with
-              amplitude values (from 0 Hz to the maximum frequency)
-            - unit = "<unit>^2/Hz" (where <unit> is Pa for example).
+            - ``num_entities`` = 1
+            - ``location`` = "TimeFreq_sets"
+            - ``data``: Vector of amplitude values in unit^2/Hz
+            - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated to
+                amplitude values (from 0 Hz to the maximum frequency)
+            - ``unit`` = "<unit>^2/Hz" (where <unit> is Pa for example).
 
             You can use the ``ansys.dpf.core.fields_factory.create_scalar_field()`` function
             to create the field.
@@ -71,74 +71,43 @@ class ProminenceRatio(PsychoacousticsParent):
         self.__operator = Operator("compute_PR")
 
     @property
-    def psd(self):
-        """Power spectral density."""
-        return self.__psd  # pragma: no cover
-
-    @psd.setter
-    def psd(self, psd: Field):
-        """Set the PSD.
-
-        Parameters
-        -------
-        psd : Field
-            PSD of the signal to compute PR on as a DPF field.
-
-            The PSD field has the following characteristics:
-
-            - num_entities = 1
-            - location = "TimeFreq_sets"
-            - data: Vector of amplitude values in unit^2/Hz
-            - time_freq_support: Vector of regularly spaced frequencies in Hz associated to
-              amplitude values (from 0 Hz to the maximum frequency)
-            - unit = "<unit>^2/Hz" (where <unit> is Pa for example).
-
-            You can use the ``ansys.dpf.core.fields_factory.create_scalar_field()`` function
-            to create the field.
-        """
-        self.__psd = psd
-
-    @psd.getter
     def psd(self) -> Field:
-        """Power spectral density.
+        """Input power spectral density (PSD) as a DPF field.
 
-        Returns
-        -------
-        Field
-            PSD of the signal to compute PR on as a DPF field.
+        The PSD field has the following characteristics:
+
+        - ``num_entities`` = 1
+        - ``location`` = "TimeFreq_sets"
+        - ``data``: Vector of amplitude values in unit^2/Hz
+        - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated to
+            amplitude values (from 0 Hz to the maximum frequency)
+        - ``unit`` = "<unit>^2/Hz" (where <unit> is Pa for example).
+
+        You can use the ``ansys.dpf.core.fields_factory.create_scalar_field()`` function
+        to create the field.
         """
         return self.__psd
 
+    @psd.setter
+    def psd(self, psd: Field):
+        """Set the PSD."""
+        self.__psd = psd
+
     @property
-    def frequency_list(self):
-        """Frequency list."""
-        return self.__frequency_list  # pragma: no cover
+    def frequency_list(self) -> list[float]:
+        """Tone frequency list in Hz.
 
-    @frequency_list.setter
-    def frequency_list(self, frequency_list: list):
-        """Set the frequency list.
-
-        Parameters
-        -------
-        frequency_list : list
-            List of the frequencies in Hz of the tones (peaks in the spectrum) to
-            calculate the PR for. If this parameter is empty (not specified), a peak
-            detection method is applied to automatically find the tones in the input
-            spectrum. Then, the PR is calculated for each detected tone.
-        """
-        self.__frequency_list = frequency_list
-
-    @frequency_list.getter
-    def frequency_list(self) -> list:
-        """Frequency list.
-
-        Returns
-        -------
-        list
-            List of the frequencies in Hz of the tones (peaks in the spectrum) to
-            calculate the PR on.
+        List of the frequencies in Hz of the tones (peaks in the PSD) where the PR shall be
+        calculated. If this parameter is unspecified (``None``), a peak detection algorithm is
+        applied to locate the tones in the input PSD. Then, the PR is calculated for each detected
+        tone.
         """
         return self.__frequency_list
+
+    @frequency_list.setter
+    def frequency_list(self, frequency_list: list[float]):
+        """Set the tone frequency list."""
+        self.__frequency_list = frequency_list
 
     def process(self):
         """Compute the PR.

--- a/src/ansys/sound/core/psychoacoustics/prominence_ratio.py
+++ b/src/ansys/sound/core/psychoacoustics/prominence_ratio.py
@@ -52,7 +52,7 @@ class ProminenceRatio(PsychoacousticsParent):
             - ``num_entities`` = 1
             - ``location`` = "TimeFreq_sets"
             - ``data``: Vector of amplitude values in unit^2/Hz
-            - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated to
+            - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated with
                 amplitude values (from 0 Hz to the maximum frequency)
             - ``unit`` = "<unit>^2/Hz" (where <unit> is Pa for example).
 
@@ -79,7 +79,7 @@ class ProminenceRatio(PsychoacousticsParent):
         - ``num_entities`` = 1
         - ``location`` = "TimeFreq_sets"
         - ``data``: Vector of amplitude values in unit^2/Hz
-        - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated to
+        - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated with
             amplitude values (from 0 Hz to the maximum frequency)
         - ``unit`` = "<unit>^2/Hz" (where <unit> is Pa for example).
 

--- a/src/ansys/sound/core/psychoacoustics/roughness.py
+++ b/src/ansys/sound/core/psychoacoustics/roughness.py
@@ -55,32 +55,14 @@ class Roughness(PsychoacousticsParent):
         self.__operator = Operator("compute_roughness")
 
     @property
-    def signal(self):
-        """Signal."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> Field | FieldsContainer:
+        """Input sound signal in Pa as a DPF field or fields container."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field | FieldsContainer):
-        """Set the signal.
-
-        Parameters
-        ----------
-        signal : Field | FieldsContainer
-            Signal in Pa to compute roughness on as a DPF field or fields container.
-
-        """
+        """Set the signal."""
         self.__signal = signal
-
-    @signal.getter
-    def signal(self) -> Field | FieldsContainer:
-        """Signal.
-
-        Returns
-        -------
-        Field | FieldsContainer
-            Signal in Pa as a DPF field or fields container.
-        """
-        return self.__signal
 
     def process(self):
         """Compute the roughness.

--- a/src/ansys/sound/core/psychoacoustics/sharpness.py
+++ b/src/ansys/sound/core/psychoacoustics/sharpness.py
@@ -47,32 +47,14 @@ class Sharpness(PsychoacousticsParent):
         self.__operator = Operator("compute_sharpness")
 
     @property
-    def signal(self):
-        """Signal."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> Field | FieldsContainer:
+        """Input sound signal in Pa as a DPF field or fields container."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field | FieldsContainer):
-        """Set the signal.
-
-        Parameters
-        -------
-        signal : Field | FieldsContainer
-            Signal in Pa to compute sharpness on as a DPF field or fields container.
-
-        """
+        """Set the signal."""
         self.__signal = signal
-
-    @signal.getter
-    def signal(self) -> Field | FieldsContainer:
-        """Signal.
-
-        Returns
-        -------
-        FieldsContainer | Field
-            Signal in Pa as a DPF field or fields container.
-        """
-        return self.__signal
 
     def process(self):
         """Compute the sharpness.

--- a/src/ansys/sound/core/psychoacoustics/spectral_centroid.py
+++ b/src/ansys/sound/core/psychoacoustics/spectral_centroid.py
@@ -40,38 +40,21 @@ class SpectralCentroid(PsychoacousticsParent):
         Parameters
         ----------
         signal : Field
-            Signal to compute spectral centroid on as a DPF field.
+            Signal on which to compute spectral centroid as a DPF field.
         """
         super().__init__()
         self.signal = signal
         self.__operator = Operator("compute_spectral_centroid")
 
     @property
-    def signal(self):
-        """Signal."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> Field:
+        """Input sound signal as a DPF field."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field):
-        """Set the signal.
-
-        Parameters
-        -------
-        signal : Field
-            Signal to compute spectral centroid on as a DPF field.
-        """
+        """Set the signal."""
         self.__signal = signal
-
-    @signal.getter
-    def signal(self) -> Field:
-        """Signal.
-
-        Returns
-        -------
-        Field
-            Signal as a DPF field.
-        """
-        return self.__signal
 
     def process(self):
         """Compute the spectral centroid."""

--- a/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio.py
+++ b/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio.py
@@ -52,7 +52,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
             - ``num_entities`` = 1
             - ``location`` = "TimeFreq_sets"
             - ``data``: Vector of amplitude values in unit^2/Hz
-            - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated to
+            - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated with
                 amplitude values (from 0 Hz to the maximum frequency)
             - ``unit`` = "<unit>^2/Hz" (where <unit> is Pa for example).
 
@@ -79,7 +79,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
         - ``num_entities`` = 1
         - ``location`` = "TimeFreq_sets"
         - ``data``: Vector of amplitude values in unit^2/Hz
-        - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated to
+        - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated with
             amplitude values (from 0 Hz to the maximum frequency)
         - ``unit`` = "<unit>^2/Hz" (where <unit> is Pa for example).
 

--- a/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio.py
+++ b/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio.py
@@ -49,12 +49,12 @@ class ToneToNoiseRatio(PsychoacousticsParent):
             PSD of the signal to compute TNR on as a DPF field.
             The PSD field has the following characteristics:
 
-            - num_entities = 1
-            - location = "TimeFreq_sets"
-            - data: Vector of amplitude values in unit^2/Hz
-            - time_freq_support: Vector of regularly spaced frequencies in Hz associated with
-              amplitude values (from 0 Hz to the maximum frequency)
-            - unit = "<unit>^2/Hz" (where <unit> is Pa for example)
+            - ``num_entities`` = 1
+            - ``location`` = "TimeFreq_sets"
+            - ``data``: Vector of amplitude values in unit^2/Hz
+            - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated to
+                amplitude values (from 0 Hz to the maximum frequency)
+            - ``unit`` = "<unit>^2/Hz" (where <unit> is Pa for example).
 
             You can use the ``ansys.dpf.core.fields_factory.create_scalar_field()`` function
             to create the field.
@@ -71,72 +71,43 @@ class ToneToNoiseRatio(PsychoacousticsParent):
         self.__operator = Operator("compute_TNR")
 
     @property
-    def psd(self):
-        """Power spectral density."""
-        return self.__psd  # pragma: no cover
-
-    @psd.setter
-    def psd(self, psd: Field):
-        """Set the PSD.
-
-        Parameters
-        -------
-        psd : Field
-            PSD of the signal to compute TNR on as a DPF field.
-            The PSD field has the following characteristics:
-
-            - num_entities = 1
-            - location = "TimeFreq_sets"
-            - data: vector of amplitude values in unit^2/Hz
-            - time_freq_support: Vector of regularly spaced frequencies in Hz associated with
-              amplitude values (from 0 Hz to the maximum frequency)
-            - unit = "<unit>^2/Hz" (where <unit> is Pa for example)
-
-            You can use the ``ansys.dpf.core.fields_factory.create_scalar_field()`` function
-            to create the field.
-        """
-        self.__psd = psd
-
-    @psd.getter
     def psd(self) -> Field:
-        """Power spectral density.
+        """Input power spectral density (PSD) as a DPF field.
 
-        Returns
-        -------
-        Field
-            PSD of the signal to compute TNR on as a DPF field.
+        The PSD field has the following characteristics:
+
+        - ``num_entities`` = 1
+        - ``location`` = "TimeFreq_sets"
+        - ``data``: Vector of amplitude values in unit^2/Hz
+        - ``time_freq_support``: Vector of regularly spaced frequencies in Hz associated to
+            amplitude values (from 0 Hz to the maximum frequency)
+        - ``unit`` = "<unit>^2/Hz" (where <unit> is Pa for example).
+
+        You can use the ``ansys.dpf.core.fields_factory.create_scalar_field()`` function
+        to create the field.
         """
         return self.__psd
 
+    @psd.setter
+    def psd(self, psd: Field):
+        """Set the PSD."""
+        self.__psd = psd
+
     @property
-    def frequency_list(self):
-        """Frequency list."""
-        return self.__frequency_list  # pragma: no cover
+    def frequency_list(self) -> list[float]:
+        """Tone frequency list in Hz.
+
+        List of the frequencies in Hz of the tones (peaks in the PSD) where the TNR shall be
+        calculated. If this parameter is unspecified (``None``), a peak detection algorithm is
+        applied to locate the tones in the input PSD. Then, the TNR is calculated for each detected
+        tone.
+        """
+        return self.__frequency_list
 
     @frequency_list.setter
     def frequency_list(self, frequency_list: list):
-        """Set the frequency list.
-
-        Parameters
-        -------
-        frequency_list : list
-            List of the frequencies in Hz of the tones (peaks in the spectrum)
-            to calculate the TNR on. If this input is empty (not specified), a peak
-            detection method is applied to automatically find the tones in the input
-            spectrum. Then, the TNR is calculated for each detected tone.
-        """
+        """Set the tone frequency list."""
         self.__frequency_list = frequency_list
-
-    @frequency_list.getter
-    def frequency_list(self) -> list:
-        """Get a list of the frequencies in Hz of the tones to calculate TNR for.
-
-        Returns
-        -------
-        list
-            Frequencies in Hz of the tones (peaks in the spectrum) to calculate TNR for.
-        """
-        return self.__frequency_list
 
     def process(self):
         """Compute the TNR.

--- a/src/ansys/sound/core/signal_utilities/apply_gain.py
+++ b/src/ansys/sound/core/signal_utilities/apply_gain.py
@@ -77,7 +77,7 @@ class ApplyGain(SignalUtilitiesParent):
 
     @property
     def gain_in_db(self) -> bool:
-        """``True`` if input gain is in dB, or ``False`` if it is linear unit.
+        """``True`` if input gain is in dB, or ``False`` if it is in linear unit.
 
         Boolean that indicates whether the input gain is provided in decibels (``True``) or in
         linear unit (``False``).

--- a/src/ansys/sound/core/signal_utilities/apply_gain.py
+++ b/src/ansys/sound/core/signal_utilities/apply_gain.py
@@ -56,85 +56,43 @@ class ApplyGain(SignalUtilitiesParent):
         self.__operator = Operator("apply_gain")
 
     @property
-    def signal(self):
-        """Signal."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> Field | FieldsContainer:
+        """Input signal as a DPF field or fields container."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field | FieldsContainer):
         """Set the signal."""
         self.__signal = signal
 
-    @signal.getter
-    def signal(self) -> Field | FieldsContainer:
-        """Signal.
-
-        Returns
-        -------
-        FieldsContainer | Field
-            Signal as a DPF field or fields container.
-        """
-        return self.__signal
-
     @property
-    def gain(self):
-        """Gain value."""
-        return self.__gain  # pragma: no cover
+    def gain(self) -> float:
+        """Gain value in dB or in linear unit (depending on ``gain_in_db`` value)."""
+        return self.__gain
 
     @gain.setter
     def gain(self, new_gain: float):
-        """Set a new gain value.
-
-        Parameters
-        ----------
-        new_gain : float
-            New gain value.
-        """
+        """Set a new gain value."""
         self.__gain = new_gain
 
-    @gain.getter
-    def gain(self) -> float:
-        """Gain value.
-
-        Returns
-        -------
-        float
-            Gain value.
-        """
-        return self.__gain
-
     @property
-    def gain_in_db(self):
-        """Gain in decibels (dB)."""
-        return self.__gain_in_db  # pragma: no cover
+    def gain_in_db(self) -> bool:
+        """``True`` if input gain is in dB, or ``False`` if it is linear unit.
+
+        Boolean that indicates whether the input gain is provided in decibels (``True``) or in
+        linear unit (``False``).
+        """
+        return self.__gain_in_db
 
     @gain_in_db.setter
     def gain_in_db(self, new_gain_in_db: bool):
-        """Set a new value for gain in decibels (dB).
-
-        Parameters
-        ----------
-        new_gain_in_db : bool
-            Whether to set the new gain in decibels(dB). When ``False``, gain is
-            set in a linear unit.
-        """
+        """Set gain_in_db (bool)."""
         if type(new_gain_in_db) is not bool:
             raise PyAnsysSoundException(
                 "'new_gain_in_db' must be a Boolean value. Specify 'True' or 'False'."
             )
 
         self.__gain_in_db = new_gain_in_db
-
-    @gain_in_db.getter
-    def gain_in_db(self) -> bool:
-        """Flag indicating if the gain is in decibels (dB).
-
-        Returns
-        -------
-        bool
-            ``True`` if gain is in decibels, ``False`` if it is in a linear unit.
-        """
-        return self.__gain_in_db
 
     def process(self):
         """Apply a gain to the signal.

--- a/src/ansys/sound/core/signal_utilities/apply_gain.py
+++ b/src/ansys/sound/core/signal_utilities/apply_gain.py
@@ -86,7 +86,7 @@ class ApplyGain(SignalUtilitiesParent):
 
     @gain_in_db.setter
     def gain_in_db(self, new_gain_in_db: bool):
-        """Set gain_in_db (bool)."""
+        """Set gain_in_db."""
         if type(new_gain_in_db) is not bool:
             raise PyAnsysSoundException(
                 "'new_gain_in_db' must be a Boolean value. Specify 'True' or 'False'."

--- a/src/ansys/sound/core/signal_utilities/create_sound_field.py
+++ b/src/ansys/sound/core/signal_utilities/create_sound_field.py
@@ -82,7 +82,7 @@ class CreateSoundField(SignalUtilitiesParent):
 
     @property
     def sampling_frequency(self) -> float:
-        """Sampling frequency of the data in Hz."""
+        """Sampling frequency in Hz of the data."""
         return self.__sampling_frequency
 
     @sampling_frequency.setter

--- a/src/ansys/sound/core/signal_utilities/create_sound_field.py
+++ b/src/ansys/sound/core/signal_utilities/create_sound_field.py
@@ -61,81 +61,36 @@ class CreateSoundField(SignalUtilitiesParent):
         self.__operator = Operator("create_field_from_vector")
 
     @property
-    def data(self):
-        """Data."""
-        return self.__data  # pragma: no cover
+    def data(self) -> npt.ArrayLike:
+        """Data to store in the created DPF field."""
+        return self.__data
 
     @data.setter
     def data(self, data: npt.ArrayLike):
         """Set the data."""
         self.__data = data
 
-    @data.getter
-    def data(self) -> npt.ArrayLike:
-        """Get data.
-
-        Returns
-        -------
-        np.array
-            Data as a NumPy array.
-        """
-        return self.__data
-
     @property
-    def unit(self):
-        """Unit."""
-        return self.__unit  # pragma: no cover
+    def unit(self) -> str:
+        """Unit of the data to store."""
+        return self.__unit
 
     @unit.setter
     def unit(self, new_unit: str):
-        """Set a new unit.
-
-        Parameters
-        ----------
-        new_unit : str
-            New unit as a string.
-        """
+        """Set a new unit."""
         self.__unit = new_unit
 
-    @unit.getter
-    def unit(self) -> str:
-        """Get the unit.
-
-        Returns
-        -------
-        str
-            Unit.
-        """
-        return self.__unit
-
     @property
-    def sampling_frequency(self):
-        """Sampling frequency."""
-        return self.__sampling_frequency  # pragma: no cover
+    def sampling_frequency(self) -> float:
+        """Sampling frequency of the data in Hz."""
+        return self.__sampling_frequency
 
     @sampling_frequency.setter
     def sampling_frequency(self, new_sampling_frequency: float):
-        """Set a new sampling frequency.
-
-        Parameters
-        ----------
-        new_sampling_frequency : float
-            New sampling frequency in Hz.
-        """
+        """Set a new sampling frequency."""
         if new_sampling_frequency < 0.0:
             raise PyAnsysSoundException("Sampling frequency must be greater than or equal to 0.0.")
         self.__sampling_frequency = new_sampling_frequency
-
-    @sampling_frequency.getter
-    def sampling_frequency(self) -> float:
-        """Get the sampling frequency.
-
-        Returns
-        -------
-        float
-            Sampling frequency.
-        """
-        return self.__sampling_frequency
 
     def process(self):
         """Create the PyAnsys Sound field.

--- a/src/ansys/sound/core/signal_utilities/crop_signal.py
+++ b/src/ansys/sound/core/signal_utilities/crop_signal.py
@@ -54,48 +54,25 @@ class CropSignal(SignalUtilitiesParent):
         self.__operator = Operator("get_cropped_signal")
 
     @property
-    def start_time(self):
-        """Start time."""
-        return self.__start_time  # pragma: no cover
+    def start_time(self) -> float:
+        """Start time of the part to crop in s."""
+        return self.__start_time
 
     @start_time.setter
     def start_time(self, new_start: float):
-        """Set a new start time.
-
-        Parameters
-        ----------
-        new_start : float
-            New start time in seconds.
-        """
+        """Set a new start time."""
         if new_start < 0.0:
             raise PyAnsysSoundException("Start time must be greater than or equal to 0.0.")
         self.__start_time = new_start
 
-    @start_time.getter
-    def start_time(self) -> float:
-        """Start time.
-
-        Returns
-        -------
-        float
-            Start time.
-        """
-        return self.__start_time
-
     @property
-    def end_time(self):
-        """End time."""
-        return self.__end_time  # pragma: no cover
+    def end_time(self) -> float:
+        """End time of the part to crop in s."""
+        return self.__end_time
 
     @end_time.setter
     def end_time(self, new_end: float):
-        """Set a new end time.
-
-        Parameters
-        ----------
-        new_end : float
-            New end time in seconds.
-        """
+        """Set a new end time."""
         if new_end < 0.0:
             raise PyAnsysSoundException("End time must be greater than or equal to 0.0.")
 
@@ -104,37 +81,15 @@ class CropSignal(SignalUtilitiesParent):
 
         self.__end_time = new_end
 
-    @end_time.getter
-    def end_time(self) -> float:
-        """End time.
-
-        Returns
-        -------
-        float
-            End time.
-        """
-        return self.__end_time
-
     @property
-    def signal(self):
-        """Signal."""
-        return self.__signal  # pragma: no cover*
+    def signal(self) -> Field | FieldsContainer:
+        """Input signal as a DPF field or fields container."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field | FieldsContainer):
         """Set the signal."""
         self.__signal = signal
-
-    @signal.getter
-    def signal(self) -> Field | FieldsContainer:
-        """Signal.
-
-        Returns
-        -------
-        Field | FieldsContainer
-            Signal as a DPF field or fields container
-        """
-        return self.__signal
 
     def process(self):
         """Crop the signal.

--- a/src/ansys/sound/core/signal_utilities/load_wav.py
+++ b/src/ansys/sound/core/signal_utilities/load_wav.py
@@ -48,31 +48,14 @@ class LoadWav(SignalUtilitiesParent):
         self.__operator = Operator("load_wav_sas")
 
     @property
-    def path_to_wav(self):
+    def path_to_wav(self) -> str:
         """Path to the WAV file."""
-        return self.__path_to_wav  # pragma: no cover
+        return self.__path_to_wav
 
     @path_to_wav.setter
     def path_to_wav(self, path_to_wav: str):
-        """Set the path to the WAV file.
-
-        Parameters
-        ----------
-        path_to_wav : str
-            Path to the WAV file.
-        """
+        """Set the path to the WAV file."""
         self.__path_to_wav = path_to_wav
-
-    @path_to_wav.getter
-    def path_to_wav(self) -> str:
-        """Path to the WAV file.
-
-        Returns
-        -------
-        str
-            Path to the WAV file.
-        """
-        return self.__path_to_wav
 
     def process(self):
         """Load the WAV file.

--- a/src/ansys/sound/core/signal_utilities/resample.py
+++ b/src/ansys/sound/core/signal_utilities/resample.py
@@ -52,55 +52,27 @@ class Resample(SignalUtilitiesParent):
         self.__operator = Operator("resample")
 
     @property
-    def new_sampling_frequency(self):
-        """New sampling frequency."""
-        return self.__new_sampling_frequency  # pragma: no cover
+    def new_sampling_frequency(self) -> float:
+        """New sampling frequency in Hz."""
+        return self.__new_sampling_frequency
 
     @new_sampling_frequency.setter
     def new_sampling_frequency(self, new_sampling_frequency: float):
-        """Set a new sampling frequency.
-
-        Parameters
-        ----------
-        new_sampling_frequency : float
-            New sampling frequency.
-        """
+        """Set a new sampling frequency."""
         if new_sampling_frequency < 0.0:
             raise PyAnsysSoundException("Sampling frequency must be greater than 0.0.")
 
         self.__new_sampling_frequency = new_sampling_frequency
 
-    @new_sampling_frequency.getter
-    def new_sampling_frequency(self) -> float:
-        """Get the new sampling frequency.
-
-        Returns
-        -------
-        float
-            New sampling frequency.
-        """
-        return self.__new_sampling_frequency
-
     @property
-    def signal(self):
-        """Signal."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> Field | FieldsContainer:
+        """Input signal as a DPF field or fields container."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field | FieldsContainer):
         """Set the signal."""
         self.__signal = signal
-
-    @signal.getter
-    def signal(self) -> Field | FieldsContainer:
-        """Signal.
-
-        Returns
-        -------
-        Field | FieldsContainer
-            Signal as a DPF field or fields container.
-        """
-        return self.__signal
 
     def process(self):
         """Resample the signal.

--- a/src/ansys/sound/core/signal_utilities/sum_signals.py
+++ b/src/ansys/sound/core/signal_utilities/sum_signals.py
@@ -46,25 +46,14 @@ class SumSignals(SignalUtilitiesParent):
         self.__operator = Operator("sum_signals")
 
     @property
-    def signals(self):
-        """Signals."""
-        return self.__signals  # pragma: no cover
+    def signals(self) -> FieldsContainer:
+        """Input signals as a DPF fields container."""
+        return self.__signals
 
     @signals.setter
     def signals(self, signals: FieldsContainer):
         """Set the signals to sum."""
         self.__signals = signals
-
-    @signals.getter
-    def signals(self) -> FieldsContainer:
-        """Signals.
-
-        Returns
-        -------
-        FieldsContainer
-            Signals as a DPF fields container.
-        """
-        return self.__signals
 
     def process(self):
         """Sum signals.

--- a/src/ansys/sound/core/signal_utilities/write_wav.py
+++ b/src/ansys/sound/core/signal_utilities/write_wav.py
@@ -47,8 +47,8 @@ class WriteWav(SignalUtilitiesParent):
             of the object or with the ``LoadWav.set_path()`` method.
         bit_depth : str, default: 'float32'
             Bit depth. Options are ``'float32'``, ``'int32'``, ``'int16'``, and ``'int8'``.
-            This means that the samples are respectively coded into the WAV file
-            using 32 bits (32-bit IEEE Float), 32 bits (int), 16 bits (int), or 8 bits (int).
+            These mean that the samples are coded into the WAV file using 32 bits (32-bit IEEE
+            Float), 32 bits (int), 16 bits (int), or 8 bits (int), respectively.
         """
         super().__init__()
         self.path_to_write = path_to_write
@@ -57,83 +57,44 @@ class WriteWav(SignalUtilitiesParent):
         self.__operator = Operator("write_wav_sas")
 
     @property
-    def signal(self):
-        """Signal."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> FieldsContainer:
+        """Input signal as a DPF fields container."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: FieldsContainer):
-        """Setter for the signal.
-
-        Sets the value of the signal to write to the disk.
-        """
+        """Setter for the signal."""
         self.__signal = signal
 
-    @signal.getter
-    def signal(self) -> FieldsContainer:
-        """Signal.
-
-        Returns
-        -------
-        FieldsContainer
-            Signal to write to the disk as a DPF fields container.
-        """
-        return self.__signal
-
     @property
-    def bit_depth(self):
-        """Bit depth."""
-        return self.__bit_depth  # pragma: no cover
+    def bit_depth(self) -> str:
+        """Bit depth.
+
+        Options are ``'float32'``, ``'int32'``, ``'int16'``, and ``'int8'``. These mean that the
+        samples are coded into the WAV file using 32 bits (32-bit IEEE Float), 32 bits (int),
+        16 bits (int), or 8 bits (int), respectively.
+        """
+        return self.__bit_depth
 
     @bit_depth.setter
     def bit_depth(self, bit_depth: str):
-        """Setter for the bit depth.
-
-        Sets the bit depth.
-        """
-        if (
-            bit_depth != "int8"
-            and bit_depth != "int16"
-            and bit_depth != "int32"
-            and bit_depth != "float32"
-        ):
+        """Sets the bit depth."""
+        if bit_depth not in ("int8", "int16", "int32", "float32"):
             raise PyAnsysSoundException(
                 "Bit depth is invalid. Accepted values are 'float32', 'int32', 'int16', and 'int8'."
             )
 
         self.__bit_depth = bit_depth
 
-    @bit_depth.getter
-    def bit_depth(self) -> str:
-        """Bit depth.
-
-        Returns
-        -------
-        str
-            Bit depth.
-        """
-        return self.__bit_depth
-
     @property
-    def path_to_write(self):
-        """Path to write the WAV file to."""
-        return self.__path_to_write  # pragma: no cover
+    def path_to_write(self) -> str:
+        """Path of the WAV file to write."""
+        return self.__path_to_write
 
     @path_to_write.setter
     def path_to_write(self, path_to_write: str):
-        """Path to write the WAV file to."""
+        """Path of the WAV file to write."""
         self.__path_to_write = path_to_write
-
-    @path_to_write.getter
-    def path_to_write(self) -> str:
-        """Path to write the the WAV file to.
-
-        Returns
-        -------
-        str
-            Path to write the WAV file to.
-        """
-        return self.__path_to_write
 
     def process(self):
         """Write the signal to a WAV file.

--- a/src/ansys/sound/core/signal_utilities/write_wav.py
+++ b/src/ansys/sound/core/signal_utilities/write_wav.py
@@ -78,7 +78,7 @@ class WriteWav(SignalUtilitiesParent):
 
     @bit_depth.setter
     def bit_depth(self, bit_depth: str):
-        """Sets the bit depth."""
+        """Set the bit depth."""
         if bit_depth not in ("int8", "int16", "int32", "float32"):
             raise PyAnsysSoundException(
                 "Bit depth is invalid. Accepted values are 'float32', 'int32', 'int16', and 'int8'."

--- a/src/ansys/sound/core/signal_utilities/zero_pad.py
+++ b/src/ansys/sound/core/signal_utilities/zero_pad.py
@@ -49,55 +49,27 @@ class ZeroPad(SignalUtilitiesParent):
         self.__operator = Operator("append_zeros_to_signal")
 
     @property
-    def signal(self):
-        """Signal."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> Field | FieldsContainer:
+        """Input signal as a DPF field or fields container."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field | FieldsContainer):
         """Set the signal."""
         self.__signal = signal
 
-    @signal.getter
-    def signal(self) -> Field | FieldsContainer:
-        """Signal.
-
-        Returns
-        -------
-        Field | FieldsContainer
-            Signal as a DPF field or fields container.
-        """
-        return self.__signal
-
     @property
-    def duration_zeros(self):
-        """Duration zeros property."""
-        return self.__duration_zeros  # pragma: no cover
+    def duration_zeros(self) -> float:
+        """Duration in s of the zero-padding at the end of the signal."""
+        return self.__duration_zeros
 
     @duration_zeros.setter
     def duration_zeros(self, new_duration_zeros: float):
-        """Set the new duration of zeros.
-
-        Parameters
-        ----------
-        new_duration_zeros : float
-            New duration for the zero padding in seconds.
-        """
+        """Set the zero-padding duration."""
         if new_duration_zeros < 0.0:
             raise PyAnsysSoundException("Zero duration must be greater than 0.0.")
 
         self.__duration_zeros = new_duration_zeros
-
-    @duration_zeros.getter
-    def duration_zeros(self) -> float:
-        """Get the sampling frequency.
-
-        Returns
-        -------
-        float
-            Sampling frequency.
-        """
-        return self.__duration_zeros
 
     def process(self):
         """Pad the end of the signal with zeros.

--- a/src/ansys/sound/core/spectral_processing/power_spectral_density.py
+++ b/src/ansys/sound/core/spectral_processing/power_spectral_density.py
@@ -291,7 +291,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
         return np.array(self.get_PSD_dB(ref_value).data)
 
     def get_frequencies(self) -> npt.ArrayLike:
-        """Get the frequencies associated to the PSD.
+        """Get the frequencies associated with the PSD.
 
         Returns
         -------

--- a/src/ansys/sound/core/spectral_processing/power_spectral_density.py
+++ b/src/ansys/sound/core/spectral_processing/power_spectral_density.py
@@ -89,7 +89,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
     @property
     def input_signal(self) -> Field:
         """Input signal."""
-        return self.__input_signal  # pragma: no cover
+        return self.__input_signal
 
     @input_signal.setter
     def input_signal(self, value: Field):
@@ -99,7 +99,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
     @property
     def fft_size(self) -> int:
         """FFT size."""
-        return self.__fft_size  # pragma: no cover
+        return self.__fft_size
 
     @fft_size.setter
     def fft_size(self, value: int):
@@ -111,9 +111,9 @@ class PowerSpectralDensity(SpectralProcessingParent):
     @property
     def window_type(self) -> str:
         """Window type."""
-        return self.__window_type  # pragma: no cover
+        return self.__window_type
 
-    # check supporté variables
+    # Check supported window types.
     @window_type.setter
     def window_type(self, value: str):
         """Set window type."""
@@ -135,7 +135,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
     @property
     def window_length(self) -> int:
         """Window length."""
-        return self.__window_length  # pragma: no cover
+        return self.__window_length
 
     @window_length.setter
     def window_length(self, value: int):
@@ -147,7 +147,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
     @property
     def overlap(self) -> int:
         """Overlap."""
-        return self.__overlap  # pragma: no cover
+        return self.__overlap
 
     @overlap.setter
     def overlap(self, value: int):

--- a/src/ansys/sound/core/spectrogram_processing/isolate_orders.py
+++ b/src/ansys/sound/core/spectrogram_processing/isolate_orders.py
@@ -64,8 +64,7 @@ class IsolateOrders(SpectrogramProcessingParent):
             Size of the FFT used to compute the STFT.
         window_type : str, default: 'HANN'
             Window type used for the FFT computation. Options are ``'BARTLETT'``, ``'BLACKMAN'``,
-            ``'BLACKMANHARRIS'``,``'HAMMING'``, ``'HANN'``, ``'HANNING'``, ``'KAISER'``, and
-            ``'RECTANGULAR'``.
+            ``'BLACKMANHARRIS'``,``'HAMMING'``, ``'HANN'``, ``'KAISER'``, and ``'RECTANGULAR'``.
         window_overlap : float, default: 0.5
             Overlap value between two successive FFT computations. Values can range from 0 to 1.
             For example, ``0`` means no overlap, and ``0.5`` means 50% overlap.
@@ -84,40 +83,18 @@ class IsolateOrders(SpectrogramProcessingParent):
         self.__operator = Operator("isolate_orders")
 
     @property
-    def signal(self):
-        """Signal."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> Field | FieldsContainer:
+        """Input signal as a DPF field or fields container."""
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field | FieldsContainer):
         """Set the signal."""
         self.__signal = signal
 
-    @signal.getter
-    def signal(self) -> Field | FieldsContainer:
-        """Signal.
-
-        Returns
-        -------
-        Field | FieldsContainer
-            Signal as a DPF field or fields container.
-        """
-        return self.__signal
-
     @property
-    def rpm_profile(self):
-        """RPM profile."""
-        return self.__rpm_profile  # pragma: no cover
-
-    @rpm_profile.getter
     def rpm_profile(self) -> Field:
-        """RPM profile.
-
-        Returns
-        -------
-        Field
-            RPM profile.
-        """
+        """RPM profile as a DPF field."""
         return self.__rpm_profile
 
     @rpm_profile.setter
@@ -126,18 +103,10 @@ class IsolateOrders(SpectrogramProcessingParent):
         self.__rpm_profile = rpm_profile
 
     @property
-    def orders(self):
-        """Orders."""
-        return self.__orders  # pragma: no cover
-
-    @orders.getter
     def orders(self) -> Field:
-        """Orders.
+        """List of the order numbers to isolate.
 
-        Returns
-        -------
-        list
-            Orders.
+        Can be provided as a list or a DPF field, but will be stored as DPF field regardless.
         """
         return self.__orders
 
@@ -148,114 +117,76 @@ class IsolateOrders(SpectrogramProcessingParent):
             f = Field()
             f.append(orders, 1)
             self.__orders = f
-        elif type(orders):
+        else:
             self.__orders = orders
 
     @property
-    def fft_size(self):
-        """FFT size."""
-        return self.__fft_size  # pragma: no cover
+    def fft_size(self) -> int:
+        """Number of FFT points."""
+        return self.__fft_size
 
     @fft_size.setter
-    def fft_size(self, fft_size):
+    def fft_size(self, fft_size: int):
         """Set the FFT size."""
         if fft_size < 0:
             raise PyAnsysSoundException("FFT size must be greater than 0.0.")
         self.__fft_size = fft_size
 
-    @fft_size.getter
-    def fft_size(self) -> float:
-        """FFT size.
-
-        Returns
-        -------
-        float
-            FFT size.
-        """
-        return self.__fft_size
-
     @property
-    def window_type(self):
-        """Window type."""
-        return self.__window_type  # pragma: no cover
+    def window_type(self) -> str:
+        """Window type.
+
+        Supported options are ``'BARTLETT'``, ``'BLACKMAN'``, ``'BLACKMANHARRIS'``, ``'HAMMING'``,
+        ``'HANN'``, ``'KAISER'``, ``'RECTANGULAR'``.
+        """
+        return self.__window_type
 
     @window_type.setter
-    def window_type(self, window_type):
+    def window_type(self, window_type: str):
         """Set the window type."""
-        if (
-            window_type != "BLACKMANHARRIS"
-            and window_type != "HANN"
-            and window_type != "HAMMING"
-            and window_type != "HANNING"
-            and window_type != "KAISER"
-            and window_type != "BARTLETT"
-            and window_type != "BLACKMAN"
-            and window_type != "RECTANGULAR"
+        if window_type not in (
+            "BLACKMANHARRIS",
+            "HANN",
+            "HAMMING",
+            "KAISER",
+            "BARTLETT",
+            "BLACKMAN",
+            "RECTANGULAR",
         ):
             raise PyAnsysSoundException(
-                "Invalid window type, accepted values are 'HANNING', 'BLACKMANHARRIS', 'HANN', "
+                "Invalid window type, accepted values are 'BLACKMANHARRIS', 'HANN', "
                 "'BLACKMAN','HAMMING', 'KAISER', 'BARTLETT', 'RECTANGULAR'."
             )
 
         self.__window_type = window_type
 
-    @window_type.getter
-    def window_type(self) -> str:
-        """Window type.
-
-        Returns
-        -------
-        str
-            Window type.
-        """
-        return self.__window_type
-
     @property
-    def window_overlap(self):
-        """Window overlap."""
-        return self.__window_overlap  # pragma: no cover
+    def window_overlap(self) -> float:
+        """Window overlap in %."""
+        return self.__window_overlap
 
     @window_overlap.setter
-    def window_overlap(self, window_overlap):
+    def window_overlap(self, window_overlap: float):
         """Set the window overlap."""
         if window_overlap < 0.0 or window_overlap > 1.0:
             raise PyAnsysSoundException("Window overlap must be between 0.0 and 1.0.")
 
         self.__window_overlap = window_overlap
 
-    @window_overlap.getter
-    def window_overlap(self) -> float:
-        """Window overlap.
-
-        Returns
-        -------
-        float
-            Window overlap.
-        """
-        return self.__window_overlap
-
     @property
-    def width_selection(self):
-        """Width selection."""
-        return self.__width_selection  # pragma: no cover
+    def width_selection(self) -> int:
+        """Width in Hz of each individual order selection.
+
+        Results may vary depending on ``fft_size`` value.
+        """
+        return self.__width_selection
 
     @width_selection.setter
-    def width_selection(self, widt_selection):
+    def width_selection(self, widt_selection: int):
         """Set the width selection."""
         if widt_selection < 0:
             raise PyAnsysSoundException("Width selection must be greater than 0.0.")
         self.__width_selection = widt_selection
-
-    @width_selection.getter
-    def width_selection(self) -> int:
-        """Width selection.
-
-        Returns
-        -------
-        int
-            Width selection.
-        """
-        return self.__width_selection
 
     def process(self):
         """Isolate the orders of the signal.

--- a/src/ansys/sound/core/spectrogram_processing/istft.py
+++ b/src/ansys/sound/core/spectrogram_processing/istft.py
@@ -50,9 +50,12 @@ class Istft(SpectrogramProcessingParent):
         self.__operator = Operator("compute_istft")
 
     @property
-    def stft(self):
-        """Short-time Fourier transform."""
-        return self.__stft  # pragma: no cover
+    def stft(self) -> FieldsContainer:
+        """Input short-time Fourier transform as a DPF fields container.
+
+        STFT format is the same as that which is produced by the ``Stft`` class.
+        """
+        return self.__stft
 
     @stft.setter
     def stft(self, stft: FieldsContainer):
@@ -71,17 +74,6 @@ class Istft(SpectrogramProcessingParent):
             )
 
         self.__stft = stft
-
-    @stft.getter
-    def stft(self) -> FieldsContainer:
-        """Short-time Fourier transform.
-
-        Returns
-        -------
-        FieldsContainer
-            STFT as a DPF fields container.
-        """
-        return self.__stft
 
     def process(self):
         """Compute the ISTFT.

--- a/src/ansys/sound/core/spectrogram_processing/stft.py
+++ b/src/ansys/sound/core/spectrogram_processing/stft.py
@@ -68,9 +68,13 @@ class Stft(SpectrogramProcessingParent):
         self.__operator = Operator("compute_stft")
 
     @property
-    def signal(self):
-        """Signal."""
-        return self.__signal  # pragma: no cover
+    def signal(self) -> Field:
+        """Input signal as a DPF field.
+
+        Can be provided as a DPF field or fields container, but will be stored as DPF field
+        regardless.
+        """
+        return self.__signal
 
     @signal.setter
     def signal(self, signal: Field | FieldsContainer):
@@ -85,21 +89,10 @@ class Stft(SpectrogramProcessingParent):
         else:
             self.__signal = signal
 
-    @signal.getter
-    def signal(self) -> Field:
-        """Signal.
-
-        Returns
-        -------
-        Field
-            Signal as a DPF field.
-        """
-        return self.__signal
-
     @property
-    def fft_size(self):
-        """FFT size."""
-        return self.__fft_size  # pragma: no cover
+    def fft_size(self) -> int:
+        """Number of FFT points."""
+        return self.__fft_size
 
     @fft_size.setter
     def fft_size(self, fft_size: int):
@@ -108,24 +101,17 @@ class Stft(SpectrogramProcessingParent):
             raise PyAnsysSoundException("FFT size must be greater than 0.0.")
         self.__fft_size = fft_size
 
-    @fft_size.getter
-    def fft_size(self) -> float:
-        """FFT size.
-
-        Returns
-        -------
-        float
-            FFT size.
-        """
-        return self.__fft_size
-
     @property
-    def window_type(self):
-        """Window type property."""
-        return self.__window_type  # pragma: no cover
+    def window_type(self) -> str:
+        """Window type.
+
+        Supported options are ``'BARTLETT'``, ``'BLACKMAN'``, ``'BLACKMANHARRIS'``, ``'HAMMING'``,
+        ``'HANN'``, ``'KAISER'``, ``'RECTANGULAR'``.
+        """
+        return self.__window_type
 
     @window_type.setter
-    def window_type(self, window_type):
+    def window_type(self, window_type: str):
         """Set the window type."""
         if window_type not in [
             "BARTLETT",
@@ -143,40 +129,18 @@ class Stft(SpectrogramProcessingParent):
 
         self.__window_type = window_type
 
-    @window_type.getter
-    def window_type(self) -> str:
-        """Window type.
-
-        Returns
-        -------
-        str
-            Window type.
-        """
-        return self.__window_type
-
     @property
-    def window_overlap(self):
-        """Window overlap."""
-        return self.__window_overlap  # pragma: no cover
+    def window_overlap(self) -> float:
+        """Window overlap in %."""
+        return self.__window_overlap
 
     @window_overlap.setter
-    def window_overlap(self, window_overlap):
+    def window_overlap(self, window_overlap: float):
         """Window overlap."""
         if window_overlap < 0.0 or window_overlap > 1.0:
             raise PyAnsysSoundException("Window overlap must be between 0.0 and 1.0.")
 
         self.__window_overlap = window_overlap
-
-    @window_overlap.getter
-    def window_overlap(self) -> float:
-        """Window overlap.
-
-        Returns
-        -------
-        float
-            Window overlap.
-        """
-        return self.__window_overlap
 
     def process(self):
         """Compute the STFT.

--- a/src/ansys/sound/core/xtract/xtract.py
+++ b/src/ansys/sound/core/xtract/xtract.py
@@ -114,13 +114,10 @@ class Xtract(XtractParent):
     def input_signal(self) -> FieldsContainer | Field:
         """Input signal.
 
-        Returns
-        -------
-        FieldsContainer | Field
-            One or more signals to apply the Xtract processing on as a
-            DPF fields container or field.
+        One or more signals on which to apply the Xtract processing, as a DPF field or fields
+        container.
         """
-        return self.__input_signal  # pragma: no cover
+        return self.__input_signal
 
     @input_signal.setter
     def input_signal(self, value: FieldsContainer | Field):
@@ -131,12 +128,9 @@ class Xtract(XtractParent):
     def parameters_denoiser(self) -> XtractDenoiserParameters:
         """Parameters of the denoiser step.
 
-        Returns
-        -------
-        XtractDenoiserParameters
-            Structure that contains the parameters of the denoising step:
+        Structure that contains the parameters of the denoising step:
 
-            - Noise PSD (field): Power spectral density of the noise.
+        - Power spectral density of the noise as a DPF field.
         """
         return self.__parameters_denoiser
 
@@ -149,19 +143,16 @@ class Xtract(XtractParent):
     def parameters_tonal(self) -> XtractTonalParameters:
         """Parameters of the tonal extraction step.
 
-        Returns
-        -------
-        GenericDataContainer
-            Structure that contains the parameters of the tonal extraction step:
+        Structure that contains the parameters of the tonal extraction step:
 
-            - NFFT (int) is the number of points used for the FFT computation.
-            - Regularity setting (float) in percent.
-            - Maximum slope (float) in dB/Hz.
-            - Minimum duration (float) in seconds (s).
-            - Intertonal gap (float) in Hz.
-            - Local emergence (float) in dB.
+        - NFFT (int) is the number of points used for the FFT computation.
+        - Regularity setting (float) between 0 and 1.
+        - Maximum slope (float) in dB/Hz.
+        - Minimum duration (float) in seconds (s).
+        - Intertonal gap (float) in Hz.
+        - Local emergence (float) in dB.
         """
-        return self.__parameters_tonal  # pragma: no cover
+        return self.__parameters_tonal
 
     @parameters_tonal.setter
     def parameters_tonal(self, value: XtractTonalParameters):
@@ -172,15 +163,12 @@ class Xtract(XtractParent):
     def parameters_transient(self) -> XtractTransientParameters:
         """Parameters of the transient extraction step.
 
-        Returns
-        -------
-        XtractTransientParameters
-            Structure that contains the parameters of the transient extraction step:
+        Structure that contains the parameters of the transient extraction step:
 
-            - Lower threshold (float), which is between 0 and 100 percent.
-            - Upper threshold (float), which is between 0 and 100 percent
+        - Lower threshold (float), which is between 0 and 100.
+        - Upper threshold (float), which is between 0 and 100.
         """
-        return self.__parameters_transient  # pragma: no cover
+        return self.__parameters_transient
 
     @parameters_transient.setter
     def parameters_transient(self, value: XtractTransientParameters):
@@ -191,23 +179,17 @@ class Xtract(XtractParent):
     def output_noise_signal(self) -> Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]:
         """Noise signal.
 
-        Returns
-        -------
-        Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]
-            Noise signal in a tuple as DPF fields containers or fields.
+        Noise signal in a tuple of DPF fields or fields containers.
         """
-        return self.__output_noise_signal  # pragma: no cover
+        return self.__output_noise_signal
 
     @property
     def output_tonal_signal(self) -> Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]:
         """Tonal signal.
 
-        Returns
-        -------
-        Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]
-            Tonal signal in a tuple as DPF fields containers or fields.
+        Tonal signal in a tuple of DPF fields or fields containers.
         """
-        return self.__output_tonal_signal  # pragma: no cover
+        return self.__output_tonal_signal
 
     @property
     def output_transient_signal(
@@ -215,12 +197,9 @@ class Xtract(XtractParent):
     ) -> Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]:
         """Transient signal.
 
-        Returns
-        -------
-        Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]
-            Transient signal in a tuple as DPF fields containers or fields.
+        Transient signal in a tuple of DPF fields or fields containers.
         """
-        return self.__output_transient_signal  # pragma: no cover
+        return self.__output_transient_signal
 
     @property
     def output_remainder_signal(
@@ -228,12 +207,9 @@ class Xtract(XtractParent):
     ) -> Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]:
         """Remainder signal.
 
-        Returns
-        -------
-        Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]
-            Remainder signal in a tuple as DPF fields containers or fields.
+        Remainder signal in a tuple of DPF fields or fields containers.
         """
-        return self.__output_remainder_signal  # pragma: no cover
+        return self.__output_remainder_signal
 
     def process(self):
         """Process the Xtract algorithm."""

--- a/src/ansys/sound/core/xtract/xtract_denoiser.py
+++ b/src/ansys/sound/core/xtract/xtract_denoiser.py
@@ -74,14 +74,11 @@ class XtractDenoiser(XtractParent):
     def input_signal(self) -> FieldsContainer | Field:
         """Input signal.
 
-        Returns
-        -------
-        FieldsContainer | Field
-            One or more signals to denoise as a DPF fields container or field. When inputting a
-            fields container, each signal (each field of the fields container) is processed
-            individually.
+        One or more signals to denoise, as a DPF field or fields container. When inputting a
+        fields container, each signal (each field of the fields container) is processed
+        individually.
         """
-        return self.__input_signal  # pragma: no cover
+        return self.__input_signal
 
     @input_signal.setter
     def input_signal(self, value: FieldsContainer | Field):
@@ -92,12 +89,11 @@ class XtractDenoiser(XtractParent):
     def input_parameters(self) -> XtractDenoiserParameters:
         """Input parameters.
 
-        Returns
-        -------
-        XtractDenoiserParameters
-            Structure that contains the parameters of the algorithm.
+        Structure that contains the parameters of the algorithm:
+         
+        - Power spectral density of the noise, as a DPF field.
         """
-        return self.__input_parameters  # pragma: no cover
+        return self.__input_parameters
 
     @input_parameters.setter
     def input_parameters(self, value: XtractDenoiserParameters):
@@ -108,25 +104,19 @@ class XtractDenoiser(XtractParent):
     def output_denoised_signals(self) -> FieldsContainer | Field:
         """Output denoised signals.
 
-        Returns
-        -------
-        FieldsContainer | Field
-            One or more denoised signals as a DPF fields container or field (depending on
-            the input).
+        One or more denoised signals as a DPF field or fields container (depending on
+        the input).
         """
-        return self.__output_denoised_signals  # pragma: no cover
+        return self.__output_denoised_signals
 
     @property
     def output_noise_signals(self) -> FieldsContainer | Field:
         """Output noise signals.
 
-        Returns
-        -------
-        FieldsContainer | Field
-            One or more noise signals as a DPF fields container or field (depending on the input).
-            The noise signal is the original signal minus the denoised signal.
+        One or more noise signals as a DPF field or fields container (depending on the input).
+        The noise signal is the original signal minus the denoised signal.
         """
-        return self.__output_noise_signals  # pragma: no cover
+        return self.__output_noise_signals
 
     def process(self):
         """Apply denoising."""

--- a/src/ansys/sound/core/xtract/xtract_denoiser.py
+++ b/src/ansys/sound/core/xtract/xtract_denoiser.py
@@ -90,7 +90,7 @@ class XtractDenoiser(XtractParent):
         """Input parameters.
 
         Structure that contains the parameters of the algorithm:
-         
+
         - Power spectral density of the noise, as a DPF field.
         """
         return self.__input_parameters

--- a/src/ansys/sound/core/xtract/xtract_denoiser_parameters.py
+++ b/src/ansys/sound/core/xtract/xtract_denoiser_parameters.py
@@ -56,9 +56,9 @@ class XtractDenoiserParameters(XtractParent):
         self.noise_psd = noise_psd
 
     @property
-    def noise_psd(self):
+    def noise_psd(self) -> Field:
         """Power spectral density (PSD) of the noise in unit^2/Hz (Pa^2/Hz for example)."""
-        return self.__generic_data_container.get_property(ID_NOISE_PSD)  # pragma: no cover
+        return self.__generic_data_container.get_property(ID_NOISE_PSD)
 
     @noise_psd.setter
     def noise_psd(self, noise_psd: Field):
@@ -67,17 +67,6 @@ class XtractDenoiserParameters(XtractParent):
             raise PyAnsysSoundException("Noise PSD must be a non-empty field.")
 
         self.__generic_data_container.set_property(ID_NOISE_PSD, noise_psd)
-
-    @noise_psd.getter
-    def noise_psd(self) -> Field:
-        """Power spectral density (PSD) of the noise in unit^2/Hz (Pa^2/Hz for example).
-
-        Returns
-        -------
-        Field
-            Noise PSD as a DPF field.
-        """
-        return self.__generic_data_container.get_property(ID_NOISE_PSD)
 
     def get_parameters_as_generic_data_container(self) -> GenericDataContainer:
         """Get the parameters as a generic data container.

--- a/src/ansys/sound/core/xtract/xtract_tonal.py
+++ b/src/ansys/sound/core/xtract/xtract_tonal.py
@@ -55,11 +55,11 @@ class XtractTonal(XtractParent):
             Structure that contains the parameters of the algorithm:
 
             - NFFT (int) is the number of points used for the FFT computation.
-            - Regularity setting (float) in percent.
+            - Regularity setting (float) between 0 and 1.
             - Maximum slope (float) in dB/Hz.
             - Minimum duration (float) in seconds.
             - Intertonal gap (float) in Hz.
-            - Local smergence (float) in dB.
+            - Local emergence (float) in dB.
 
             This structure is of the ``XtractTonalParameters`` type. For more information,
             see this class.
@@ -80,15 +80,11 @@ class XtractTonal(XtractParent):
     def input_signal(self) -> FieldsContainer | Field:
         """Input signal.
 
-        Returns
-        -------
-        FieldsContainer | Field
-            One or more signals to extract tonal components from
-            as a DPF fields container or field.
-            When inputting a fields container, each signal (each field of the fields container)
-            is processed individually.
+        One or more signals from which to extract tonal components, as a DPF field or fields
+        container. When inputting a fields container, each signal (each field of the fields
+        container) is processed individually.
         """
-        return self.__input_signal  # pragma: no cover
+        return self.__input_signal
 
     @input_signal.setter
     def input_signal(self, value: FieldsContainer | Field):
@@ -99,17 +95,14 @@ class XtractTonal(XtractParent):
     def input_parameters(self) -> XtractTonalParameters:
         """Input parameters.
 
-        Returns
-        -------
-        GenericDataContainer
-            Structure that contains the parameters of the algorithm:
+        Structure that contains the parameters of the algorithm:
 
-            - NFFT (int) is the number of points used for the FFT computation.
-            - Regularity setting (float) in percent.
-            - Maximum slope (float) in dB/Hz.
-            - Minimum duration (float) in seconds (s).
-            - Intertonal gap (float) in Hz.
-            - Local smergence (float) in dB.
+        - NFFT (int) is the number of points used for the FFT computation.
+        - Regularity setting (float) between 0 and 1.
+        - Maximum slope (float) in dB/Hz.
+        - Minimum duration (float) in seconds (s).
+        - Intertonal gap (float) in Hz.
+        - Local emergence (float) in dB.
         """
         return self.__input_parameters
 
@@ -122,24 +115,17 @@ class XtractTonal(XtractParent):
     def output_tonal_signals(self) -> FieldsContainer | Field:
         """Output tonal signals.
 
-        Returns
-        -------
-        FieldsContainer | Field
-            One or more tonal signals as a DPF fields container or field (depending on the input).
+        One or more tonal signals as a DPF field or fields container (depending on the input).
         """
-        return self.__output_tonal_signals  # pragma: no cover
+        return self.__output_tonal_signals
 
     @property
     def output_non_tonal_signals(self) -> FieldsContainer | Field:
         """Output non-tonal signals.
 
-        Returns
-        -------
-        FieldsContainer | Field
-            One or more non-tonal signals as a DPF fields container or field (depending on
-            the input).
+        One or more non-tonal signals as a DPF field or fields container (depending on the input).
         """
-        return self.__output_non_tonal_signals  # pragma: no cover
+        return self.__output_non_tonal_signals
 
     def process(self):
         """Process the tonal analysis."""

--- a/src/ansys/sound/core/xtract/xtract_tonal_parameters.py
+++ b/src/ansys/sound/core/xtract/xtract_tonal_parameters.py
@@ -85,9 +85,14 @@ class XtractTonalParameters(XtractParent):
         super().__init__()
 
     @property
-    def regularity(self):
-        """Regularity."""
-        return self.__generic_data_container.get_property(ID_REGULARITY)  # pragma: no cover
+    def regularity(self) -> float:
+        """Regularity parameter.
+
+        Values are between 0 and 1. This parameter is designed to reject tonal components with too
+        much frequency variation. You should start with the default value (``1.0``) and then lower
+        it to remove detected tonals whose frequency evolutions are too erratic.
+        """
+        return self.__generic_data_container.get_property(ID_REGULARITY)
 
     @regularity.setter
     def regularity(self, regularity: float):
@@ -97,21 +102,14 @@ class XtractTonalParameters(XtractParent):
 
         self.__generic_data_container.set_property(ID_REGULARITY, regularity)
 
-    @regularity.getter
-    def regularity(self) -> float:
-        """Regularity.
-
-        Returns
-        -------
-        float
-            Regularity.
-        """
-        return self.__generic_data_container.get_property(ID_REGULARITY)
-
     @property
-    def maximum_slope(self):
-        """Maximum slope."""
-        return self.__generic_data_container.get_property(ID_MAXIMUM_SLOPE)  # pragma: no cover
+    def maximum_slope(self) -> float:
+        """Maximum slope in Hz/s.
+
+        Maximum slope in Hz/s for each tonal component. Values are between 0 and 15000 Hz/s.
+        A higher value enables finding tonal components with a greater frequency slope over time.
+        """
+        return self.__generic_data_container.get_property(ID_MAXIMUM_SLOPE)
 
     @maximum_slope.setter
     def maximum_slope(self, maximum_slope: float):
@@ -121,21 +119,13 @@ class XtractTonalParameters(XtractParent):
 
         self.__generic_data_container.set_property(ID_MAXIMUM_SLOPE, maximum_slope)
 
-    @maximum_slope.getter
-    def maximum_slope(self) -> float:
-        """Maximum slope.
-
-        Returns
-        -------
-        float
-            Maximum slope.
-        """
-        return self.__generic_data_container.get_property(ID_MAXIMUM_SLOPE)
-
     @property
-    def minimum_duration(self):
-        """Minimum duration."""
-        return self.__generic_data_container.get_property(ID_MINIMUM_DURATION)  # pragma: no cover
+    def minimum_duration(self) -> float:
+        """Minimum duration in s.
+
+        Minimum duration in seconds for each tonal component. Values are between 0 and 5 s.
+        """
+        return self.__generic_data_container.get_property(ID_MINIMUM_DURATION)
 
     @minimum_duration.setter
     def minimum_duration(self, minimum_duration: float):
@@ -145,21 +135,13 @@ class XtractTonalParameters(XtractParent):
 
         self.__generic_data_container.set_property(ID_MINIMUM_DURATION, minimum_duration)
 
-    @minimum_duration.getter
-    def minimum_duration(self) -> float:
-        """Minimum duration.
-
-        Returns
-        -------
-        float
-            Minimum duration.
-        """
-        return self.__generic_data_container.get_property(ID_MINIMUM_DURATION)
-
     @property
-    def intertonal_gap(self):
-        """Intertonal gap."""
-        return self.__generic_data_container.get_property(ID_INTERTONAL_GAP)  # pragma: no cover
+    def intertonal_gap(self) -> float:
+        """Intertonal gap in Hz.
+
+        Minimum gap in Hz between two tonal components. Values are between 10 and 200 Hz.
+        """
+        return self.__generic_data_container.get_property(ID_INTERTONAL_GAP)
 
     @intertonal_gap.setter
     def intertonal_gap(self, intertonal_gap: float):
@@ -169,21 +151,14 @@ class XtractTonalParameters(XtractParent):
 
         self.__generic_data_container.set_property(ID_INTERTONAL_GAP, intertonal_gap)
 
-    @intertonal_gap.getter
-    def intertonal_gap(self) -> float:
-        """Intertonal gap.
-
-        Returns
-        -------
-        float
-            Intertonal gap.
-        """
-        return self.__generic_data_container.get_property(ID_INTERTONAL_GAP)
-
     @property
-    def local_emergence(self):
-        """Local emergence."""
-        return self.__generic_data_container.get_property(ID_LOCAL_EMERGENCE)  # pragma: no cover
+    def local_emergence(self) -> float:
+        """Local emergence in dB.
+
+        Emergence in dB of the tonal components compared to the background noise. Values are
+        between 0 and 100 dB.
+        """
+        return self.__generic_data_container.get_property(ID_LOCAL_EMERGENCE)
 
     @local_emergence.setter
     def local_emergence(self, local_emergence: float):
@@ -193,21 +168,10 @@ class XtractTonalParameters(XtractParent):
 
         self.__generic_data_container.set_property(ID_LOCAL_EMERGENCE, local_emergence)
 
-    @local_emergence.getter
-    def local_emergence(self) -> float:
-        """Local emergence.
-
-        Returns
-        -------
-        float
-            Local emergence.
-        """
-        return self.__generic_data_container.get_property(ID_LOCAL_EMERGENCE)
-
     @property
-    def fft_size(self):
-        """FFT size."""
-        return self.__generic_data_container.get_property(ID_FFT_SIZE)  # pragma: no cover
+    def fft_size(self) -> int:
+        """Number of FFT points."""
+        return self.__generic_data_container.get_property(ID_FFT_SIZE)
 
     @fft_size.setter
     def fft_size(self, fft_size: int):
@@ -216,17 +180,6 @@ class XtractTonalParameters(XtractParent):
             raise PyAnsysSoundException("FFT size must be greater than 0.")
 
         self.__generic_data_container.set_property(ID_FFT_SIZE, fft_size)
-
-    @fft_size.getter
-    def fft_size(self) -> int:
-        """FFT size.
-
-        Returns
-        -------
-        int
-            FFT size.
-        """
-        return self.__generic_data_container.get_property(ID_FFT_SIZE)
 
     def get_parameters_as_generic_data_container(self) -> GenericDataContainer:
         """Get the parameters as a generic data container.

--- a/src/ansys/sound/core/xtract/xtract_transient.py
+++ b/src/ansys/sound/core/xtract/xtract_transient.py
@@ -75,79 +75,49 @@ class XtractTransient(XtractParent):
     def input_signal(self) -> FieldsContainer | Field:
         """Input signal.
 
-        Returns
-        -------
-        FieldsContainer | Field
-            One or more signals to extract transient components on
-            as a DPF fields container or field. When inputting a fields container,
-            each signal (each field of the fields container) is processed individually.
+        One or more signals from which to extract transient components, as a DPF field or fields
+        container. When inputting a fields container, each signal (each field of the fields
+        container) is processed individually.
         """
-        return self.__input_signal  # pragma: no cover
+        return self.__input_signal
 
     @input_signal.setter
     def input_signal(self, value: FieldsContainer | Field):
-        """Set input signal.
-
-        Parameters
-        ----------
-        value : FieldsContainer | Field
-            One or more signal to extract transient components on
-            as a DPF fields container or field. When inputting a fields container,
-            each signal (each field of the fields container) is processed individually.
-        """
+        """Set input signal."""
         self.__input_signal = value
 
     @property
     def input_parameters(self) -> XtractTransientParameters:
         """Input parameters.
 
-        Returns
-        -------
-        XtractTransientParameters
-            Structure that contains the parameters of the algorithm:
+        Structure that contains the parameters of the algorithm:
 
-            - Lower threshold (float), which is between 0 and 100 percent
-            - Upper threshold (float), which is between 0 and 100 percent
+        - Lower threshold (float), which is between 0 and 100.
+        - Upper threshold (float), which is between 0 and 100.
         """
-        return self.__input_parameters  # pragma: no cover
+        return self.__input_parameters
 
     @input_parameters.setter
     def input_parameters(self, value: XtractTransientParameters):
-        """Set input parameters.
-
-        Parameters
-        ----------
-        value : XtractTransientParameters
-            Structure that contains the parameters of the algorithm:
-
-            - Lower threshold (float), which is between 0 and 100 percent
-            - Upper threshold (float), which is between 0 and 100 percent
-        """
+        """Set input parameters."""
         self.__input_parameters = value
 
     @property
     def output_transient_signals(self) -> FieldsContainer | Field:
         """Output transient signals.
 
-        Returns
-        -------
-        FieldsContainer | Field
-            One or more transient signals as a DPF fields container or field (depending on
-            the input).
+        One or more transient signals as a DPF field or fields container (depending on the input).
         """
-        return self.__output_transient_signals  # pragma: no cover
+        return self.__output_transient_signals
 
     @property
     def output_non_transient_signals(self) -> FieldsContainer | Field:
         """Output non-transient signals.
 
-        Returns
-        -------
-        FieldsContainer | Field
-            One or more non-transient signals (original signal minus transient signal)
-            as a DPF fields container or field (depending on the input).
+        One or more non-transient signals (original signal minus transient signal) as a DPF field
+        or fields container (depending on the input).
         """
-        return self.__output_non_transient_signals  # pragma: no cover
+        return self.__output_non_transient_signals
 
     def process(self):
         """Process the transient extraction.

--- a/src/ansys/sound/core/xtract/xtract_transient_parameters.py
+++ b/src/ansys/sound/core/xtract/xtract_transient_parameters.py
@@ -45,7 +45,7 @@ class XtractTransientParameters(XtractParent):
             Values are between 0 and 100. You should set this parameter as high as possible
             provided that no transient element remains in the remainder (non-transient signal).
         upper_threshold : float, default: 100.0
-            Maximum threshold in dB, which is related to the maximum energy of transient components.
+            Maximum threshold, which is related to the maximum energy of transient components.
             Values are between 0 and 100. You should set this parameter as low as possible provided
             that no transient element remains in the remainder (non-transient signal).
         """
@@ -55,9 +55,14 @@ class XtractTransientParameters(XtractParent):
         self.upper_threshold = upper_threshold
 
     @property
-    def lower_threshold(self):
-        """Lower threshold."""
-        return self.__generic_data_container.get_property(ID_LOWER_THRESHOLD)  # pragma: no cover
+    def lower_threshold(self) -> float:
+        """Lower threshold.
+
+        Lower threshold, which is related to the minimum energy of transient components.
+        Values are between 0 and 100. You should set this parameter as high as possible
+        provided that no transient element remains in the remainder (non-transient signal).
+        """
+        return self.__generic_data_container.get_property(ID_LOWER_THRESHOLD)
 
     @lower_threshold.setter
     def lower_threshold(self, lower_threshold: float):
@@ -67,21 +72,15 @@ class XtractTransientParameters(XtractParent):
 
         self.__generic_data_container.set_property(ID_LOWER_THRESHOLD, lower_threshold)
 
-    @lower_threshold.getter
-    def lower_threshold(self) -> float:
-        """Lower threshold in decibels (dB).
-
-        Returns
-        -------
-        float
-            Lower threshold in decibels.
-        """
-        return self.__generic_data_container.get_property(ID_LOWER_THRESHOLD)
-
     @property
-    def upper_threshold(self):
-        """Upper threshold in decibels (dB)."""
-        return self.__generic_data_container.get_property(ID_UPPER_THRESHOLD)  # pragma: no cover
+    def upper_threshold(self) -> float:
+        """Upper threshold.
+
+        Maximum threshold, which is related to the maximum energy of transient components.
+        Values are between 0 and 100. You should set this parameter as low as possible provided
+        that no transient element remains in the remainder (non-transient signal).
+        """
+        return self.__generic_data_container.get_property(ID_UPPER_THRESHOLD)
 
     @upper_threshold.setter
     def upper_threshold(self, upper_threshold: float):
@@ -90,17 +89,6 @@ class XtractTransientParameters(XtractParent):
             raise PyAnsysSoundException("Upper threshold must be between 0.0 and 100.0 dB.")
 
         self.__generic_data_container.set_property(ID_UPPER_THRESHOLD, upper_threshold)
-
-    @upper_threshold.getter
-    def upper_threshold(self) -> float:
-        """Upper threshold in decibels (dB).
-
-        Returns
-        -------
-        float
-            Upper threshold in decibels.
-        """
-        return self.__generic_data_container.get_property(ID_UPPER_THRESHOLD)
 
     def get_parameters_as_generic_data_container(self) -> GenericDataContainer:
         """Get the parameters as a generic data container.

--- a/tests/tests_spectrogram_processing/test_spectrogram_processing_isolate_orders.py
+++ b/tests/tests_spectrogram_processing/test_spectrogram_processing_isolate_orders.py
@@ -186,8 +186,7 @@ def test_isolate_orders_set_get_window_type(dpf_sound_test_server):
     with pytest.raises(PyAnsysSoundException) as excinfo:
         isolate_orders.window_type = "InvalidWindow"
     assert (
-        str(excinfo.value)
-        == "Invalid window type, accepted values are 'HANNING', 'BLACKMANHARRIS', 'HANN',"
+        str(excinfo.value) == "Invalid window type, accepted values are 'BLACKMANHARRIS', 'HANN',"
         " 'BLACKMAN','HAMMING', 'KAISER', 'BARTLETT', 'RECTANGULAR'."
     )
 


### PR DESCRIPTION
- Remove unnecessary explicit getter when a property is defined.
- Add details and consistency in the property docstring.
- Add return hint for each property
- Clean up unnecessary details in setter docstring (+ some missing argument type hints)
- Remove pragma nocover, as it is no longer necessary

Unrelated:
- Added ``SpectralCentroid`` in doc
- Removed 'hanning' from supported options for ``IsolateOrders.window_type``
- Fixed incomplete type test for ``IsolateOrders.orders``
- Fixed a few errors/typos in docstrings