### PR TITLE
docs: sort out doc and type hints for numpy arrays

### DIFF
--- a/doc/changelog.d/171.documentation.md
+++ b/doc/changelog.d/171.documentation.md
@@ -1,1 +1,1 @@
-doc: sort out doc and type hints for numpy arrays
+docs: sort out doc and type hints for numpy arrays

--- a/doc/changelog.d/171.documentation.md
+++ b/doc/changelog.d/171.documentation.md
@@ -1,0 +1,1 @@
+doc: sort out doc and type hints for numpy arrays

--- a/examples/002_load_resample_amplify_write_wav_files.py
+++ b/examples/002_load_resample_amplify_write_wav_files.py
@@ -94,7 +94,7 @@ fc_signal_modified = gain_applier.get_output()
 # ~~~~~~~~~~~~
 # Plot both the original signal and modified signal.
 
-# Get the signals as nparray
+# Get the signals as NumPy arrays
 data_original = wav_loader.get_output_as_nparray()
 data_modified = gain_applier.get_output_as_nparray()
 

--- a/src/ansys/sound/core/_pyansys_sound.py
+++ b/src/ansys/sound/core/_pyansys_sound.py
@@ -25,7 +25,6 @@ import warnings
 
 from ansys.dpf.core import FieldsContainer
 import numpy as np
-from numpy.typing import ArrayLike
 
 
 class PyAnsysSound:
@@ -76,20 +75,20 @@ class PyAnsysSound:
         warnings.warn(PyAnsysSoundWarning("There is nothing to output."))
         return self._output
 
-    def get_output_as_nparray(self) -> ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get output as a NumPy array.
 
         There is nothing to output.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Empty NumPy array.
         """
         warnings.warn(PyAnsysSoundWarning("There is nothing to output."))
         return np.empty(0)
 
-    def convert_fields_container_to_np_array(self, fc) -> ArrayLike:
+    def convert_fields_container_to_np_array(self, fc) -> np.ndarray:
         """Convert a DPF fields container to a NumPy array.
 
         This method converts a multichannel signal contained in a DPF fields container to a
@@ -102,7 +101,7 @@ class PyAnsysSound:
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             DPF fields container in a NumPy array.
         """
         num_channels = len(fc)

--- a/src/ansys/sound/core/psychoacoustics/_psychoacoustics_parent.py
+++ b/src/ansys/sound/core/psychoacoustics/_psychoacoustics_parent.py
@@ -22,7 +22,7 @@
 
 """Psychoacoustics functions."""
 from ansys.dpf.core import Field
-from numpy import typing as npt
+import numpy as np
 
 from .._pyansys_sound import PyAnsysSound, PyAnsysSoundException
 
@@ -34,7 +34,7 @@ class PsychoacousticsParent(PyAnsysSound):
     This is the base class for all pychoacoustics indicators classes and should not be used as is.
     """
 
-    def _convert_bark_to_hertz(self, bark_band_indexes: npt.ArrayLike) -> npt.ArrayLike:
+    def _convert_bark_to_hertz(self, bark_band_indexes: np.ndarray) -> np.ndarray:
         """Convert Bark band indexes into frequencies.
 
         Converts input Bark band indexes (in Bark) into corresponding frequencies (in Hz)
@@ -44,12 +44,12 @@ class PsychoacousticsParent(PyAnsysSound):
 
         Parameters
         ----------
-        bark_band_indexes : numpy.array
+        bark_band_indexes : numpy.ndarray
             Array of Bark band indexes to convert in Bark.
 
         Returns
         -------
-        numpy.array
+        numpy.ndarray
             Array of corresponding frequencies in Hz.
         """
         for ibark in range(len(bark_band_indexes)):

--- a/src/ansys/sound/core/psychoacoustics/fluctuation_strength.py
+++ b/src/ansys/sound/core/psychoacoustics/fluctuation_strength.py
@@ -26,7 +26,6 @@ import warnings
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import PsychoacousticsParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -117,7 +116,7 @@ class FluctuationStrength(PsychoacousticsParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> tuple[npt.ArrayLike]:
+    def get_output_as_nparray(self) -> tuple[np.ndarray]:
         """Get fluctuation strength data in a tuple as a NumPy array.
 
         Returns
@@ -158,7 +157,7 @@ class FluctuationStrength(PsychoacousticsParent):
         """
         return self._get_output_parameter(channel_index, TOTAL_FS_ID)
 
-    def get_specific_fluctuation_strength(self, channel_index: int = 0) -> npt.ArrayLike:
+    def get_specific_fluctuation_strength(self, channel_index: int = 0) -> np.ndarray:
         """Get the specific fluctuation strength for a signal.
 
         This method gets the specific fluctuation strength in vacil/Bark for the specified
@@ -176,7 +175,7 @@ class FluctuationStrength(PsychoacousticsParent):
         """
         return self._get_output_parameter(channel_index, SPECIFIC_FS_ID)
 
-    def get_bark_band_indexes(self) -> npt.ArrayLike:
+    def get_bark_band_indexes(self) -> np.ndarray:
         """Get the Bark band indexes.
 
         This method gets the Bark band indexes used for the fluctuation strength
@@ -199,7 +198,7 @@ class FluctuationStrength(PsychoacousticsParent):
         else:
             return np.copy(specific_fluctuation_strength[0].time_freq_support.time_frequencies.data)
 
-    def get_bark_band_frequencies(self) -> npt.ArrayLike:
+    def get_bark_band_frequencies(self) -> np.ndarray:
         """Get Bark band frequencies.
 
         This method gets the frequencies corresponding to Bark band indexes as a NumPy array.
@@ -252,9 +251,7 @@ class FluctuationStrength(PsychoacousticsParent):
             plt.legend()
         plt.show()
 
-    def _get_output_parameter(
-        self, channel_index: int, output_id: str
-    ) -> np.float64 | npt.ArrayLike:
+    def _get_output_parameter(self, channel_index: int, output_id: str) -> np.float64 | np.ndarray:
         """Get individual fluctuation strength result for a signal channel.
 
         This method gets a total or specific fluctuation strength for a signal channel
@@ -273,7 +270,7 @@ class FluctuationStrength(PsychoacousticsParent):
         Returns
         -------
         numpy.float64 | numpy.ndarray
-            Fluctuation strength (float) in vacil or specific fluctuation strength (numpy array)
+            Fluctuation strength (float) in vacil or specific fluctuation strength (NumPy array)
             in vacil/Bark.
         """
         if self.get_output() == None or not (self._check_channel_index(channel_index)):

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
@@ -26,7 +26,6 @@ import warnings
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import PsychoacousticsParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -117,7 +116,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> tuple[npt.ArrayLike]:
+    def get_output_as_nparray(self) -> tuple[np.ndarray]:
         """Get loudness data in a tuple as a NumPy array.
 
         Returns
@@ -177,7 +176,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
         """
         return self._get_output_parameter(channel_index, LOUDNESS_LEVEL_PHON_ID)
 
-    def get_specific_loudness(self, channel_index: int = 0) -> npt.ArrayLike:
+    def get_specific_loudness(self, channel_index: int = 0) -> np.ndarray:
         """Get the specific loudness for a signal channel.
 
         This method gets the specific loudness in sone/Bark for a specified channel index.
@@ -194,7 +193,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
         """
         return self._get_output_parameter(channel_index, SPECIFIC_LOUDNESS_ID)
 
-    def get_bark_band_indexes(self) -> npt.ArrayLike:
+    def get_bark_band_indexes(self) -> np.ndarray:
         """Get Bark band indexes.
 
         This method gets the Bark band indexes used for the loudness calculation as a NumPy array.
@@ -216,7 +215,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
         else:
             return np.copy(specific_loudness[0].time_freq_support.time_frequencies.data)
 
-    def get_bark_band_frequencies(self) -> npt.ArrayLike:
+    def get_bark_band_frequencies(self) -> np.ndarray:
         """Get Bark band frequencies.
 
         This method gets the frequencies corresponding to Bark band indexes as a NumPy array.
@@ -270,9 +269,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
             plt.legend()
         plt.show()
 
-    def _get_output_parameter(
-        self, channel_index: int, output_id: str
-    ) -> np.float64 | npt.ArrayLike:
+    def _get_output_parameter(self, channel_index: int, output_id: str) -> np.float64 | np.ndarray:
         """Get the individual loudness result for a signal channel.
 
         This method gets the loudness or loudness level for the specified channel in phon
@@ -293,7 +290,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
         -------
         numpy.float64 | numpy.ndarray
             Loudness or loudness level value (float, in sone or phon, respectively), or specific
-            loudness (numpy array, in sone/Bark).
+            loudness (NumPy array, in sone/Bark).
         """
         if self.get_output() == None or not (self._check_channel_index(channel_index)):
             return None

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_time_varying.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_time_varying.py
@@ -26,7 +26,6 @@ import warnings
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import PsychoacousticsParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -126,7 +125,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> tuple[npt.ArrayLike]:
+    def get_output_as_nparray(self) -> tuple[np.ndarray]:
         """Get indicators for time-varying loudness in a tuple as a NumPy array.
 
         Returns
@@ -168,7 +167,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
             self.convert_fields_container_to_np_array(output[5]),
         )
 
-    def get_loudness_sone_vs_time(self, channel_index: int = 0) -> npt.ArrayLike:
+    def get_loudness_sone_vs_time(self, channel_index: int = 0) -> np.ndarray:
         """Get the time-varying loudness in sone for a signal channel.
 
         Parameters
@@ -247,7 +246,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
             N10 = self.get_output_as_nparray()[2]
             return N10[channel_index]
 
-    def get_loudness_level_phon_vs_time(self, channel_index: int = 0) -> npt.ArrayLike:
+    def get_loudness_level_phon_vs_time(self, channel_index: int = 0) -> np.ndarray:
         """Get the time-varying loudness level in phon for a signal channel.
 
         Parameters
@@ -326,7 +325,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
             L10 = self.get_output_as_nparray()[5]
             return L10[channel_index]
 
-    def get_time_scale(self) -> npt.ArrayLike:
+    def get_time_scale(self) -> np.ndarray:
         """Get the time scale.
 
         This method gets an array of the timestamps in seconds where time-varying

--- a/src/ansys/sound/core/psychoacoustics/prominence_ratio.py
+++ b/src/ansys/sound/core/psychoacoustics/prominence_ratio.py
@@ -27,7 +27,6 @@ import warnings
 from ansys.dpf.core import Field, GenericDataContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import PsychoacousticsParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -153,7 +152,7 @@ class ProminenceRatio(PsychoacousticsParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> tuple[npt.ArrayLike] | None:
+    def get_output_as_nparray(self) -> tuple[np.ndarray] | None:
         """Get PR data in a tuple as a NumPy array.
 
         Returns
@@ -203,7 +202,7 @@ class ProminenceRatio(PsychoacousticsParent):
 
         return len(self.get_output_as_nparray()[0])
 
-    def get_peaks_frequencies(self) -> npt.ArrayLike:
+    def get_peaks_frequencies(self) -> np.ndarray:
         """Get the vector of the peaks' frequencies.
 
         Returns
@@ -216,7 +215,7 @@ class ProminenceRatio(PsychoacousticsParent):
 
         return self.get_output_as_nparray()[0]
 
-    def get_PR_values(self) -> npt.ArrayLike:
+    def get_PR_values(self) -> np.ndarray:
         """Get the vector of the peaks' PR values.
 
         Returns
@@ -229,7 +228,7 @@ class ProminenceRatio(PsychoacousticsParent):
 
         return self.get_output_as_nparray()[1]
 
-    def get_peaks_levels(self) -> npt.ArrayLike:
+    def get_peaks_levels(self) -> np.ndarray:
         """Get the vector of the peaks' level values.
 
         Returns
@@ -242,7 +241,7 @@ class ProminenceRatio(PsychoacousticsParent):
 
         return self.get_output_as_nparray()[2]
 
-    def get_peaks_low_frequencies(self) -> npt.ArrayLike:
+    def get_peaks_low_frequencies(self) -> np.ndarray:
         """Get the vector of the peaks' lower-frequency limits.
 
         Returns
@@ -255,7 +254,7 @@ class ProminenceRatio(PsychoacousticsParent):
 
         return self.get_output_as_nparray()[3]
 
-    def get_peaks_high_frequencies(self) -> npt.ArrayLike:
+    def get_peaks_high_frequencies(self) -> np.ndarray:
         """Get the vector of the peaks' higher-frequency limits.
 
         Returns
@@ -319,7 +318,7 @@ class ProminenceRatio(PsychoacousticsParent):
             self.get_peaks_high_frequencies()[tone_index],
         )
 
-    def get_reference_curve(self) -> npt.ArrayLike:
+    def get_reference_curve(self) -> np.ndarray:
         """Get a reference curve to compare the PR with.
 
         Returns

--- a/src/ansys/sound/core/psychoacoustics/roughness.py
+++ b/src/ansys/sound/core/psychoacoustics/roughness.py
@@ -26,7 +26,6 @@ import warnings
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import PsychoacousticsParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -111,7 +110,7 @@ class Roughness(PsychoacousticsParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> tuple[npt.ArrayLike]:
+    def get_output_as_nparray(self) -> tuple[np.ndarray]:
         """Get roughness data in a tuple as a NumPy array.
 
         Returns
@@ -151,7 +150,7 @@ class Roughness(PsychoacousticsParent):
         """
         return self._get_output_parameter(channel_index, TOTAL_ROUGHNESS_ID)
 
-    def get_specific_roughness(self, channel_index: int = 0) -> npt.ArrayLike:
+    def get_specific_roughness(self, channel_index: int = 0) -> np.ndarray:
         """Get the specific roughness for a signal.
 
         This method gets the specific roughness in asper/Bark for the specified channel index.
@@ -168,7 +167,7 @@ class Roughness(PsychoacousticsParent):
         """
         return self._get_output_parameter(channel_index, SPECIFIC_ROUGHNESS_ID)
 
-    def get_bark_band_indexes(self) -> npt.ArrayLike:
+    def get_bark_band_indexes(self) -> np.ndarray:
         """Get Bark band indexes.
 
         This method gets the Bark band indexes used for the roughness calculation as a NumPy array.
@@ -190,7 +189,7 @@ class Roughness(PsychoacousticsParent):
         else:
             return np.copy(specific_roughness[0].time_freq_support.time_frequencies.data)
 
-    def get_bark_band_frequencies(self) -> npt.ArrayLike:
+    def get_bark_band_frequencies(self) -> np.ndarray:
         """Get Bark band frequencies.
 
         This method gets the frequencies corresponding to Bark band indexes as a NumPy array.
@@ -244,9 +243,7 @@ class Roughness(PsychoacousticsParent):
             plt.legend()
         plt.show()
 
-    def _get_output_parameter(
-        self, channel_index: int, output_id: str
-    ) -> np.float64 | npt.ArrayLike:
+    def _get_output_parameter(self, channel_index: int, output_id: str) -> np.float64 | np.ndarray:
         """Get the individual roughness result for the signal channel.
 
         This method returns the roughness as a float or the specific roughness as a
@@ -265,7 +262,7 @@ class Roughness(PsychoacousticsParent):
         Returns
         -------
         numpy.float64 | numpy.ndarray
-            Roughness (float) in asper or specific roughness (numpy array) in asper/Bark.
+            Roughness (float) in asper or specific roughness (NumPy array) in asper/Bark.
         """
         if self.get_output() == None or not (self._check_channel_index(channel_index)):
             return None

--- a/src/ansys/sound/core/psychoacoustics/sharpness.py
+++ b/src/ansys/sound/core/psychoacoustics/sharpness.py
@@ -25,7 +25,6 @@ import warnings
 
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import numpy as np
-from numpy import typing as npt
 
 from . import PsychoacousticsParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -96,7 +95,7 @@ class Sharpness(PsychoacousticsParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the sharpness as a NumPy array.
 
         Returns

--- a/src/ansys/sound/core/psychoacoustics/spectral_centroid.py
+++ b/src/ansys/sound/core/psychoacoustics/spectral_centroid.py
@@ -25,7 +25,6 @@ import warnings
 
 from ansys.dpf.core import Field, Operator
 import numpy as np
-from numpy import typing as npt
 
 from . import PsychoacousticsParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -89,7 +88,7 @@ class SpectralCentroid(PsychoacousticsParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the spectral centroid as a NumPy array.
 
         Returns

--- a/src/ansys/sound/core/psychoacoustics/tonality_din_45681.py
+++ b/src/ansys/sound/core/psychoacoustics/tonality_din_45681.py
@@ -26,7 +26,6 @@ import warnings
 from ansys.dpf.core import Field, GenericDataContainersCollection, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import PsychoacousticsParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -179,7 +178,7 @@ class TonalityDIN45681(PsychoacousticsParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> tuple[npt.ArrayLike]:
+    def get_output_as_nparray(self) -> tuple[np.ndarray]:
         """Get the DIN 45681 tonality data, in a tuple of NumPy arrays.
 
         Returns
@@ -261,7 +260,7 @@ class TonalityDIN45681(PsychoacousticsParent):
         """
         return self.get_output()[2]
 
-    def get_decisive_difference_over_time(self) -> npt.ArrayLike:
+    def get_decisive_difference_over_time(self) -> np.ndarray:
         """Get the DIN 45681 decisive difference DLj, in dB over time.
 
         Returns
@@ -271,7 +270,7 @@ class TonalityDIN45681(PsychoacousticsParent):
         """
         return self.get_output_as_nparray()[3]
 
-    def get_uncertainty_over_time(self) -> npt.ArrayLike:
+    def get_uncertainty_over_time(self) -> np.ndarray:
         """Get the DIN 45681 decisive difference uncertainty, in dB over time.
 
         Returns
@@ -281,7 +280,7 @@ class TonalityDIN45681(PsychoacousticsParent):
         """
         return self.get_output_as_nparray()[4]
 
-    def get_decisive_frequency_over_time(self) -> npt.ArrayLike:
+    def get_decisive_frequency_over_time(self) -> np.ndarray:
         """Get the DIN 45681 decisive frequency, in Hz over time.
 
         Returns
@@ -291,7 +290,7 @@ class TonalityDIN45681(PsychoacousticsParent):
         """
         return self.get_output_as_nparray()[5]
 
-    def get_tonal_adjustment_over_time(self) -> npt.ArrayLike:
+    def get_tonal_adjustment_over_time(self) -> np.ndarray:
         """Get the DIN 45681 tonal adjustment Kt, in dB over time.
 
         Returns
@@ -301,7 +300,7 @@ class TonalityDIN45681(PsychoacousticsParent):
         """
         return self.get_output_as_nparray()[6]
 
-    def get_time_scale(self) -> npt.ArrayLike:
+    def get_time_scale(self) -> np.ndarray:
         """Get the DIN 45681 time scale, in s.
 
         Returns

--- a/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio.py
+++ b/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio.py
@@ -27,7 +27,6 @@ import warnings
 from ansys.dpf.core import Field, GenericDataContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import PsychoacousticsParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -150,7 +149,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> tuple[npt.ArrayLike] | None:
+    def get_output_as_nparray(self) -> tuple[np.ndarray] | None:
         """Get TNR data in a tuple as a NumPy array.
 
         Returns
@@ -199,7 +198,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
 
         return len(self.get_output_as_nparray()[0])
 
-    def get_peaks_frequencies(self) -> npt.ArrayLike:
+    def get_peaks_frequencies(self) -> np.ndarray:
         """Get the vector of the peaks' frequencies in Hz.
 
         Returns
@@ -212,7 +211,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
 
         return self.get_output_as_nparray()[0]
 
-    def get_TNR_values(self) -> npt.ArrayLike:
+    def get_TNR_values(self) -> np.ndarray:
         """Get the vector of the peaks' TNR values in dB.
 
         Returns
@@ -225,7 +224,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
 
         return self.get_output_as_nparray()[1]
 
-    def get_peaks_levels(self) -> npt.ArrayLike:
+    def get_peaks_levels(self) -> np.ndarray:
         """Get the vector of the peaks' level values in dB SPL.
 
         Returns
@@ -238,7 +237,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
 
         return self.get_output_as_nparray()[2]
 
-    def get_peaks_low_frequencies(self) -> npt.ArrayLike:
+    def get_peaks_low_frequencies(self) -> np.ndarray:
         """Get the vector of the peaks' lower-frequency limits in Hz.
 
         Returns
@@ -251,7 +250,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
 
         return self.get_output_as_nparray()[3]
 
-    def get_peaks_high_frequencies(self) -> npt.ArrayLike:
+    def get_peaks_high_frequencies(self) -> np.ndarray:
         """Get the vector of the peaks' higher-frequency limits in Hz.
 
         Returns
@@ -315,7 +314,7 @@ class ToneToNoiseRatio(PsychoacousticsParent):
             self.get_peaks_high_frequencies()[tone_index],
         )
 
-    def get_reference_curve(self) -> npt.ArrayLike:
+    def get_reference_curve(self) -> np.ndarray:
         """Get a reference curve to compare the TNR with.
 
         Returns

--- a/src/ansys/sound/core/signal_utilities/apply_gain.py
+++ b/src/ansys/sound/core/signal_utilities/apply_gain.py
@@ -25,7 +25,7 @@
 import warnings
 
 from ansys.dpf.core import Field, FieldsContainer, Operator
-from numpy import typing as npt
+import numpy as np
 
 from . import SignalUtilitiesParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -135,12 +135,12 @@ class ApplyGain(SignalUtilitiesParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the signal with a gain as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Signal with an applied gain as a NumPy array.
         """
         output = self.get_output()

--- a/src/ansys/sound/core/signal_utilities/create_sound_field.py
+++ b/src/ansys/sound/core/signal_utilities/create_sound_field.py
@@ -25,7 +25,6 @@ import warnings
 
 from ansys.dpf.core import Field, Operator
 import numpy as np
-from numpy import typing as npt
 
 from . import SignalUtilitiesParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -39,7 +38,7 @@ class CreateSoundField(SignalUtilitiesParent):
 
     def __init__(
         self,
-        data: npt.ArrayLike = np.empty(0),
+        data: np.ndarray = np.empty(0),
         sampling_frequency: float = 44100.0,
         unit: str = "Pa",
     ):
@@ -47,7 +46,7 @@ class CreateSoundField(SignalUtilitiesParent):
 
         Parameters
         ----------
-        data : np.array, default: np.empty(0)
+        data : numpy.ndarray, default: np.empty(0)
             Data to use to create the PyAnsys Sound field as a 1D NumPy array.
         sampling_frequency : float, default: 44100.0
             Sampling frequency of the data.
@@ -61,12 +60,12 @@ class CreateSoundField(SignalUtilitiesParent):
         self.__operator = Operator("create_field_from_vector")
 
     @property
-    def data(self) -> npt.ArrayLike:
+    def data(self) -> np.ndarray:
         """Data to store in the created DPF field."""
         return self.__data
 
     @data.setter
-    def data(self, data: npt.ArrayLike):
+    def data(self, data: np.ndarray):
         """Set the data."""
         self.__data = data
 
@@ -130,12 +129,12 @@ class CreateSoundField(SignalUtilitiesParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the data as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Data in a NumPy array.
         """
         output = self.get_output()

--- a/src/ansys/sound/core/signal_utilities/crop_signal.py
+++ b/src/ansys/sound/core/signal_utilities/crop_signal.py
@@ -24,7 +24,7 @@
 import warnings
 
 from ansys.dpf.core import Field, FieldsContainer, Operator
-from numpy import typing as npt
+import numpy as np
 
 from . import SignalUtilitiesParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -134,12 +134,12 @@ class CropSignal(SignalUtilitiesParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the cropped signal as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Cropped signal in a NumPy array.
         """
         output = self.get_output()

--- a/src/ansys/sound/core/signal_utilities/load_wav.py
+++ b/src/ansys/sound/core/signal_utilities/load_wav.py
@@ -25,7 +25,7 @@
 import warnings
 
 from ansys.dpf.core import DataSources, FieldsContainer, Operator
-from numpy import typing as npt
+import numpy as np
 
 from . import SignalUtilitiesParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -101,12 +101,12 @@ class LoadWav(SignalUtilitiesParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the signal loaded from the WAV file as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Signal loaded from the WAV file in a NumPy array.
         """
         fc = self.get_output()

--- a/src/ansys/sound/core/signal_utilities/resample.py
+++ b/src/ansys/sound/core/signal_utilities/resample.py
@@ -25,7 +25,7 @@
 import warnings
 
 from ansys.dpf.core import Field, FieldsContainer, Operator
-from numpy import typing as npt
+import numpy as np
 
 from . import SignalUtilitiesParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -115,12 +115,12 @@ class Resample(SignalUtilitiesParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the resampled signal as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Resampled signal in a NumPy array.
         """
         output = self.get_output()

--- a/src/ansys/sound/core/signal_utilities/sum_signals.py
+++ b/src/ansys/sound/core/signal_utilities/sum_signals.py
@@ -24,7 +24,7 @@
 import warnings
 
 from ansys.dpf.core import Field, FieldsContainer, Operator
-from numpy import typing as npt
+import numpy as np
 
 from . import SignalUtilitiesParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -92,12 +92,12 @@ class SumSignals(SignalUtilitiesParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the signal with a gain as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Summed signal in a NumPy array.
         """
         output = self.get_output()

--- a/src/ansys/sound/core/signal_utilities/zero_pad.py
+++ b/src/ansys/sound/core/signal_utilities/zero_pad.py
@@ -24,7 +24,7 @@
 import warnings
 
 from ansys.dpf.core import Field, FieldsContainer, Operator
-from numpy import typing as npt
+import numpy as np
 
 from . import SignalUtilitiesParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -114,12 +114,12 @@ class ZeroPad(SignalUtilitiesParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the zero-padded signal as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Zero-padded signal in a NumPy array.
         """
         output = self.get_output()

--- a/src/ansys/sound/core/sound_composer/source_spectrum.py
+++ b/src/ansys/sound/core/sound_composer/source_spectrum.py
@@ -26,7 +26,6 @@ import warnings
 from ansys.dpf.core import Field, Operator
 from matplotlib import pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
 from ._source_parent import SourceParent
@@ -222,13 +221,13 @@ class SourceSpectrum(SourceParent):
             )
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
-        """Get the generated sound as a numpy array.
+    def get_output_as_nparray(self) -> np.ndarray:
+        """Get the generated sound as a NumPy array.
 
         Returns
         -------
         numpy.ndarray
-            Generated sound as a numpy array.
+            Generated sound as a NumPy array.
         """
         output = self.get_output()
 

--- a/src/ansys/sound/core/sound_power/sound_power_level_iso_3744.py
+++ b/src/ansys/sound/core/sound_power/sound_power_level_iso_3744.py
@@ -26,7 +26,6 @@ import warnings
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import SoundPowerParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -494,7 +493,7 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         return output[1]
 
-    def get_Lw_octave(self) -> npt.ArrayLike:
+    def get_Lw_octave(self) -> np.ndarray:
         """Get octave-band power sound levels.
 
         Returns
@@ -506,7 +505,7 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         return output[2]
 
-    def get_octave_center_frequencies(self) -> npt.ArrayLike:
+    def get_octave_center_frequencies(self) -> np.ndarray:
         """Get octave-band center frequencies.
 
         Returns
@@ -518,7 +517,7 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         return output[3]
 
-    def get_Lw_thirdoctave(self) -> npt.ArrayLike:
+    def get_Lw_thirdoctave(self) -> np.ndarray:
         """Get one-third-octave-band power sound levels.
 
         Returns
@@ -530,7 +529,7 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         return output[4]
 
-    def get_thirdoctave_center_frequencies(self) -> npt.ArrayLike:
+    def get_thirdoctave_center_frequencies(self) -> np.ndarray:
         """Get one-third-octave-band center frequencies.
 
         Returns

--- a/src/ansys/sound/core/spectral_processing/power_spectral_density.py
+++ b/src/ansys/sound/core/spectral_processing/power_spectral_density.py
@@ -27,7 +27,6 @@ import warnings
 from ansys.dpf.core import Field, Operator, TimeFreqSupport, fields_factory, locations
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import SpectralProcessingParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -196,8 +195,8 @@ class PowerSpectralDensity(SpectralProcessingParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> tuple[npt.ArrayLike]:
-        """Get the PSD data as numpy arrays.
+    def get_output_as_nparray(self) -> tuple[np.ndarray]:
+        """Get the PSD data as NumPy arrays.
 
         Returns
         -------
@@ -226,8 +225,8 @@ class PowerSpectralDensity(SpectralProcessingParent):
         """
         return self.get_output()
 
-    def get_PSD_squared_linear_as_nparray(self) -> tuple[npt.ArrayLike]:
-        """Get the PSD in squared linear unit, as numpy arrays.
+    def get_PSD_squared_linear_as_nparray(self) -> tuple[np.ndarray]:
+        """Get the PSD in squared linear unit, as NumPy arrays.
 
         Returns
         -------
@@ -274,8 +273,8 @@ class PowerSpectralDensity(SpectralProcessingParent):
 
         return psd_dB_field
 
-    def get_PSD_dB_as_nparray(self, ref_value: float = 1.0) -> npt.ArrayLike:
-        """Get the PSD in dB/Hz as a numpy array.
+    def get_PSD_dB_as_nparray(self, ref_value: float = 1.0) -> np.ndarray:
+        """Get the PSD in dB/Hz as a NumPy array.
 
         Parameters
         ----------
@@ -286,11 +285,11 @@ class PowerSpectralDensity(SpectralProcessingParent):
         Returns
         -------
         numpy.ndarray
-            The PSD in dB/Hz as a numpy array.
+            The PSD in dB/Hz as a NumPy array.
         """
         return np.array(self.get_PSD_dB(ref_value).data)
 
-    def get_frequencies(self) -> npt.ArrayLike:
+    def get_frequencies(self) -> np.ndarray:
         """Get the frequencies associated with the PSD.
 
         Returns

--- a/src/ansys/sound/core/spectrogram_processing/isolate_orders.py
+++ b/src/ansys/sound/core/spectrogram_processing/isolate_orders.py
@@ -26,7 +26,7 @@ import warnings
 
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
-from numpy import typing as npt
+import numpy as np
 
 from . import SpectrogramProcessingParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -244,12 +244,12 @@ class IsolateOrders(SpectrogramProcessingParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the temporal signal of the isolated orders as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Temporal signal of the isolated orders in a NumPy array.
         """
         output = self.get_output()

--- a/src/ansys/sound/core/spectrogram_processing/istft.py
+++ b/src/ansys/sound/core/spectrogram_processing/istft.py
@@ -27,7 +27,6 @@ import warnings
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import SpectrogramProcessingParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -113,12 +112,12 @@ class Istft(SpectrogramProcessingParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the ISTFT resulting signal as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             ISTFT resulting signal in a NumPy array.
         """
         output = self.get_output()

--- a/src/ansys/sound/core/spectrogram_processing/stft.py
+++ b/src/ansys/sound/core/spectrogram_processing/stft.py
@@ -27,7 +27,6 @@ import warnings
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import SpectrogramProcessingParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -180,12 +179,12 @@ class Stft(SpectrogramProcessingParent):
 
         return self._output
 
-    def get_output_as_nparray(self) -> npt.ArrayLike:
+    def get_output_as_nparray(self) -> np.ndarray:
         """Get the STFT of the signal as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             STFT of the signal in a NumPy array.
         """
         output = self.get_output()
@@ -205,23 +204,23 @@ class Stft(SpectrogramProcessingParent):
         # return out_as_np_array
         return np.transpose(out_as_np_array)
 
-    def get_stft_magnitude_as_nparray(self) -> npt.ArrayLike:
+    def get_stft_magnitude_as_nparray(self) -> np.ndarray:
         """Get the amplitude of the STFT as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Amplitude of the STFT in a NumPy array.
         """
         output = self.get_output_as_nparray()
         return np.absolute(output)
 
-    def get_stft_phase_as_nparray(self) -> npt.ArrayLike:
+    def get_stft_phase_as_nparray(self) -> np.ndarray:
         """Get the phase of the STFT as a NumPy array.
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Phase of the STFT in a NumPy array.
         """
         output = self.get_output_as_nparray()

--- a/src/ansys/sound/core/xtract/xtract.py
+++ b/src/ansys/sound/core/xtract/xtract.py
@@ -22,13 +22,11 @@
 
 """Xtract class."""
 
-from typing import Tuple
 import warnings
 
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import (
     XtractDenoiserParameters,
@@ -176,7 +174,7 @@ class Xtract(XtractParent):
         self.__parameters_transient = value
 
     @property
-    def output_noise_signal(self) -> Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]:
+    def output_noise_signal(self) -> tuple[FieldsContainer, FieldsContainer] | tuple[Field, Field]:
         """Noise signal.
 
         Noise signal in a tuple of DPF fields or fields containers.
@@ -184,7 +182,7 @@ class Xtract(XtractParent):
         return self.__output_noise_signal
 
     @property
-    def output_tonal_signal(self) -> Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]:
+    def output_tonal_signal(self) -> tuple[FieldsContainer, FieldsContainer] | tuple[Field, Field]:
         """Tonal signal.
 
         Tonal signal in a tuple of DPF fields or fields containers.
@@ -194,7 +192,7 @@ class Xtract(XtractParent):
     @property
     def output_transient_signal(
         self,
-    ) -> Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]:
+    ) -> tuple[FieldsContainer, FieldsContainer] | tuple[Field, Field]:
         """Transient signal.
 
         Transient signal in a tuple of DPF fields or fields containers.
@@ -204,7 +202,7 @@ class Xtract(XtractParent):
     @property
     def output_remainder_signal(
         self,
-    ) -> Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]:
+    ) -> tuple[FieldsContainer, FieldsContainer] | tuple[Field, Field]:
         """Remainder signal.
 
         Remainder signal in a tuple of DPF fields or fields containers.
@@ -262,15 +260,15 @@ class Xtract(XtractParent):
     def get_output(
         self,
     ) -> (
-        Tuple[FieldsContainer, FieldsContainer, FieldsContainer, FieldsContainer]
-        | Tuple[Field, Field, Field, Field]
+        tuple[FieldsContainer, FieldsContainer, FieldsContainer, FieldsContainer]
+        | tuple[Field, Field, Field, Field]
     ):
         """Get the output of the Xtract algorithm in a tuple as DPF fields containers or fields.
 
         Returns
         -------
-        Tuple[FieldsContainer, FieldsContainer, FieldsContainer, FieldsContainer] |
-        Tuple[Field, Field, Field, Field]
+        tuple[FieldsContainer, FieldsContainer, FieldsContainer, FieldsContainer] |
+        tuple[Field, Field, Field, Field]
             Noise signal, tonal signal, transient signal, and remainder signal
             in a tuple of DPF fields or fields containers.
         """
@@ -291,12 +289,12 @@ class Xtract(XtractParent):
 
     def get_output_as_nparray(
         self,
-    ) -> Tuple[npt.ArrayLike, npt.ArrayLike, npt.ArrayLike, npt.ArrayLike]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Get the output of the Xtract algorithm in a tuple as NumPy arrays.
 
         Returns
         -------
-        Tuple[numpy.array, numpy.array, numpy.array, numpy.array]
+        tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray]
             Noise signal, tonal signal, transient signal, and remainder signal in a
             tuple as NumPy arrays.
         """

--- a/src/ansys/sound/core/xtract/xtract_denoiser.py
+++ b/src/ansys/sound/core/xtract/xtract_denoiser.py
@@ -22,13 +22,11 @@
 
 """Xtract denoiser class."""
 
-from typing import Tuple
 import warnings
 
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import XtractDenoiserParameters, XtractParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -142,12 +140,12 @@ class XtractDenoiser(XtractParent):
 
         self._output = (self.__output_denoised_signals, self.__output_noise_signals)
 
-    def get_output(self) -> Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]:
+    def get_output(self) -> tuple[FieldsContainer, FieldsContainer] | tuple[Field, Field]:
         """Get the output of the denoising.
 
         Returns
         -------
-        Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]
+        tuple[FieldsContainer, FieldsContainer] | tuple[Field, Field]
             Denoised signal and noise signal in a tuple as
             DPF fields containers or fields (depending on the input).
         """
@@ -156,12 +154,12 @@ class XtractDenoiser(XtractParent):
 
         return self._output  # i.e. self.__output_denoised_signals, self.__output_noise_signals
 
-    def get_output_as_nparray(self) -> Tuple[npt.ArrayLike, npt.ArrayLike]:
+    def get_output_as_nparray(self) -> tuple[np.ndarray, np.ndarray]:
         """Get the output of the denoising as NumPy arrays.
 
         Returns
         -------
-        Tuple[npt.ArrayLike, npt.ArrayLike]
+        tuple[np.ndarray, np.ndarray]
             Denoised signal and noise signal in a tuple as NumPy arrays.
         """
         l_output_denoised_signals, l_output_noise_signals = self.get_output()

--- a/src/ansys/sound/core/xtract/xtract_tonal.py
+++ b/src/ansys/sound/core/xtract/xtract_tonal.py
@@ -22,13 +22,11 @@
 
 """Xtract tonal module."""
 
-from typing import Tuple
 import warnings
 
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import XtractParent, XtractTonalParameters
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -151,12 +149,12 @@ class XtractTonal(XtractParent):
 
         self._output = (self.__output_tonal_signals, self.__output_non_tonal_signals)
 
-    def get_output(self) -> Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]:
+    def get_output(self) -> tuple[FieldsContainer, FieldsContainer] | tuple[Field, Field]:
         """Get the output of the tonal analysis.
 
         Returns
         -------
-        Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]
+        tuple[FieldsContainer, FieldsContainer] | tuple[Field, Field]
             Tonal and non-tonal signals in a tuple as DPF fields containers or fields.
         """
         if self.__output_tonal_signals == None or self.__output_non_tonal_signals == None:
@@ -164,12 +162,12 @@ class XtractTonal(XtractParent):
 
         return self.__output_tonal_signals, self.__output_non_tonal_signals
 
-    def get_output_as_nparray(self) -> Tuple[npt.ArrayLike, npt.ArrayLike]:
+    def get_output_as_nparray(self) -> tuple[np.ndarray, np.ndarray]:
         """Get the output of the tonal analysis as NumPy arrays.
 
         Returns
         -------
-        Tuple[npt.ArrayLike, npt.ArrayLike]
+        tuple[np.ndarray, np.ndarray]
             Tonal and non-tonal signals as a tuple in NumPy arrays.
         """
         l_output_tonal_signals, l_output_non_tonal_signals = self.get_output()

--- a/src/ansys/sound/core/xtract/xtract_transient.py
+++ b/src/ansys/sound/core/xtract/xtract_transient.py
@@ -22,13 +22,11 @@
 
 """Xtract  transient module."""
 
-from typing import Tuple
 import warnings
 
 from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import typing as npt
 
 from . import XtractParent, XtractTransientParameters
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -146,12 +144,12 @@ class XtractTransient(XtractParent):
 
         self._output = (self.__output_transient_signals, self.__output_non_transient_signals)
 
-    def get_output(self) -> Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]:
+    def get_output(self) -> tuple[FieldsContainer, FieldsContainer] | tuple[Field, Field]:
         """Get the output of the transient extraction.
 
         Returns
         -------
-        Tuple[FieldsContainer, FieldsContainer] | Tuple[Field, Field]
+        tuple[FieldsContainer, FieldsContainer] | tuple[Field, Field]
             One or more transient signals and non-transient signals
             in a tuple as DPF fields containers or fields (depending on the input).
         """
@@ -160,12 +158,12 @@ class XtractTransient(XtractParent):
 
         return self.__output_transient_signals, self.__output_non_transient_signals
 
-    def get_output_as_nparray(self) -> Tuple[npt.ArrayLike, npt.ArrayLike]:
+    def get_output_as_nparray(self) -> tuple[np.ndarray, np.ndarray]:
         """Get the output of the transient extraction as NumPy arrays.
 
         Returns
         -------
-        Tuple[np.ArrayLike, np.ArrayLike]
+        tuple[numpy.ndarray, numpy.ndarray]
             Transient signals and non-transient signals in a tuple as NumPy arrays.
         """
         l_output_transient_signals, l_output_non_transient_signals = self.get_output()


### PR DESCRIPTION
 Sort out doc and type hints for numpy arrays
- Clarified all docstrings where numpy arrays were mentioned (eg 'numpy.ndarray' instead of things like 'np.array')
- Replaced all ``numpy.typing.ArrayLike`` type hints by ``numpy.ndarray`` for better clarity (and removed ``numpy.typing`` imports altogether)

Also replaced unnecessary ``Tuple`` (with capital T) type hint from ``typing``, with ``tuple`` (lowercase) from baseline types (in xtract classes)

Note: Replacing ``numpy.typing.ArrayLike`` type hints with ``numpy.ndarray`` changes the displayed "Return type" in the produced doc:
- with ``numpy.typing.ArrayLike`` type hint
![image](https://github.com/user-attachments/assets/11e6282f-b661-478b-8f7f-96c8abfbd913)

- with ``numpy.ndarray`` type hint
![image](https://github.com/user-attachments/assets/56c3de9c-ab63-4e5d-b0e6-d18cba0c8464)
