### PR TITLE
chore: supporting Python 3.13 and dropping support for Python 3.9

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:

--- a/doc/changelog.d/185.maintenance.md
+++ b/doc/changelog.d/185.maintenance.md
@@ -1,1 +1,1 @@
-maint: supporting Python 3.13 and dropping support for Python 3.9
+chore: supporting Python 3.13 and dropping support for Python 3.9

--- a/doc/changelog.d/185.maintenance.md
+++ b/doc/changelog.d/185.maintenance.md
@@ -1,0 +1,1 @@
+maint: supporting Python 3.13 and dropping support for Python 3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,16 +8,16 @@ name = "ansys-sound-core"
 version = "0.1.dev0"
 description = "A Python wrapper for Ansys DPF Sound."
 readme = "README.rst"
-requires-python = ">=3.9,<4"
+requires-python = ">=3.10,<4"
 license = { file = "LICENSE" }
 authors = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
 maintainers = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
Providing active support for Python 3.13 and dropping support for Python 3.9