### PR TITLE
ci: switch pydpfcore dependency to dev version

### DIFF
--- a/doc/changelog.d/222.maintenance.md
+++ b/doc/changelog.d/222.maintenance.md
@@ -1,0 +1,1 @@
+ci: switch pydpfcore dependency to dev version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,14 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "ansys-dpf-core>=0.9.0,<1",
+    "ansys-dpf-core@git+https://github.com/ansys/pydpf-core#egg=master",
     "matplotlib>=3.8.2,<4",
     "platformdirs>=3.6.0",
 ]
 
 [project.optional-dependencies]
 tests = [
-    "ansys-dpf-core==0.13.4",
+    "ansys-dpf-core@git+https://github.com/ansys/pydpf-core#egg=master",
     "matplotlib==3.10.0",
 
     "pytest==8.3.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 tests = [
-    "ansys-dpf-core@git+https://github.com/ansys/pydpf-core#egg=master",
     "matplotlib==3.10.0",
-
     "pytest==8.3.4",
     "pytest-cov==6.0.0",
     "pytest-dependency==0.6.0",


### PR DESCRIPTION
Switch project dependencies such that PyAnsys Sound now depends on the under-dev version of PyDPF-Core (instead of the latest release previously)

Also removed unnecessary duplicated PyDPF Core dependency for tests