### PR TITLE
fix: add field type in loudness ISO532-1 (stationary/time-varying)

### DIFF
--- a/doc/changelog.d/223.fixed.md
+++ b/doc/changelog.d/223.fixed.md
@@ -1,0 +1,1 @@
+fix: add field type in loudness ISO532-1 (stationary/time-varying)

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_time_varying.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_time_varying.py
@@ -27,8 +27,11 @@ from ansys.dpf.core import Field, FieldsContainer, Operator
 import matplotlib.pyplot as plt
 import numpy as np
 
-from . import PsychoacousticsParent
+from . import FIELD_DIFFUSE, FIELD_FREE, PsychoacousticsParent
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+
+# Name of the DPF Sound operator used in this module.
+ID_COMPUTE_LOUDNESS_ISO_TIME_VARYING = "compute_loudness_iso532_1_vs_time"
 
 
 class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
@@ -38,7 +41,11 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
     sounds.
     """
 
-    def __init__(self, signal: Field | FieldsContainer = None):
+    def __init__(
+        self,
+        signal: Field | FieldsContainer = None,
+        field_type: str = FIELD_FREE,
+    ):
         """Class instantiation takes the following parameters.
 
         Parameters
@@ -46,10 +53,13 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
         signal : Field | FieldsContainer
             Signal to compute time-varying ISO532-1 loudness on as a DPF field or fields
             container.
+        field_type : str, default: "Free"
+            Sound field type. Available options are `"Free"` and `"Diffuse"`.
         """
         super().__init__()
         self.signal = signal
-        self.__operator = Operator("compute_loudness_iso532_1_vs_time")
+        self.field_type = field_type
+        self.__operator = Operator(ID_COMPUTE_LOUDNESS_ISO_TIME_VARYING)
 
     @property
     def signal(self) -> Field | FieldsContainer:
@@ -60,6 +70,24 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
     def signal(self, signal: Field | FieldsContainer):
         """Set the signal."""
         self.__signal = signal
+
+    @property
+    def field_type(self) -> str:
+        """Sound field type.
+
+        Available options are `"Free"` and `"Diffuse"`.
+        """
+        return self.__field_type
+
+    @field_type.setter
+    def field_type(self, field_type: str):
+        """Set the sound field type."""
+        if field_type.lower() not in [FIELD_FREE.lower(), FIELD_DIFFUSE.lower()]:
+            raise PyAnsysSoundException(
+                f'Invalid field type "{field_type}". Available options are "{FIELD_FREE}" and '
+                f'"{FIELD_DIFFUSE}".'
+            )
+        self.__field_type = field_type
 
     def process(self):
         """Compute the time-varying ISO532-1 loudness.
@@ -73,6 +101,7 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
             )
 
         self.__operator.connect(0, self.signal)
+        self.__operator.connect(1, self.field_type)
 
         # Runs the operator
         self.__operator.run()

--- a/tests/tests_psychoacoustics/test_psychoacoustics_loudness_iso_532_1_stationary.py
+++ b/tests/tests_psychoacoustics/test_psychoacoustics_loudness_iso_532_1_stationary.py
@@ -30,9 +30,11 @@ from ansys.sound.core._pyansys_sound import PyAnsysSoundException, PyAnsysSoundW
 from ansys.sound.core.psychoacoustics import LoudnessISO532_1_Stationary
 from ansys.sound.core.signal_utilities import LoadWav
 
-EXP_LOUDNESS_1 = 39.58000183105469
+EXP_LOUDNESS_FREE = 39.58000183105469
+EXP_LOUDNESS_DIFFUSE = 42.02
 EXP_LOUDNESS_2 = 16.18000030517578
-EXP_LOUDNESS_LEVEL_1 = 93.0669937133789
+EXP_LOUDNESS_LEVEL_FREE = 93.0669937133789
+EXP_LOUDNESS_LEVEL_DIFFUSE = 93.93004
 EXP_LOUDNESS_LEVEL_2 = 80.16139221191406
 EXP_SPECIFIC_LOUDNESS_1_0 = 0.0
 EXP_SPECIFIC_LOUDNESS_1_9 = 0.15664348006248474
@@ -53,11 +55,13 @@ SPECIFIC_LOUDNESS_ID = "specific"
 
 
 def test_loudness_iso_532_1_stationary_instantiation():
+    """Test the instantiation of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     assert loudness_computer != None
 
 
 def test_loudness_iso_532_1_stationary_process():
+    """Test the process method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
 
     # No signal -> error
@@ -85,6 +89,7 @@ def test_loudness_iso_532_1_stationary_process():
 
 
 def test_loudness_iso_532_1_stationary_get_output():
+    """Test the get_output method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     # Get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -116,6 +121,7 @@ def test_loudness_iso_532_1_stationary_get_output():
 
 
 def test_loudness_iso_532_1_stationary_get_loudness_sone():
+    """Test the get_loudness_sone method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     # Get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -145,7 +151,7 @@ def test_loudness_iso_532_1_stationary_get_loudness_sone():
 
     loudness_sone = loudness_computer.get_loudness_sone(0)
     assert type(loudness_sone) == np.float64
-    assert loudness_sone == pytest.approx(EXP_LOUDNESS_1)
+    assert loudness_sone == pytest.approx(EXP_LOUDNESS_FREE)
 
     # Set signal as a fields container
     loudness_computer.signal = fc
@@ -154,7 +160,7 @@ def test_loudness_iso_532_1_stationary_get_loudness_sone():
 
     loudness_sone = loudness_computer.get_loudness_sone(0)
     assert type(loudness_sone) == np.float64
-    assert loudness_sone == pytest.approx(EXP_LOUDNESS_1)
+    assert loudness_sone == pytest.approx(EXP_LOUDNESS_FREE)
 
     # Add a second signal in the fields container
     # Note: No need to re-assign the signal property, as fc is simply an alias for it
@@ -167,13 +173,14 @@ def test_loudness_iso_532_1_stationary_get_loudness_sone():
 
     loudness_sone = loudness_computer.get_loudness_sone(0)
     assert type(loudness_sone) == np.float64
-    assert loudness_sone == pytest.approx(EXP_LOUDNESS_1)
+    assert loudness_sone == pytest.approx(EXP_LOUDNESS_FREE)
     loudness_sone = loudness_computer.get_loudness_sone(1)
     assert type(loudness_sone) == np.float64
     assert loudness_sone == pytest.approx(EXP_LOUDNESS_2)
 
 
 def test_loudness_iso_532_1_stationary_get_loudness_level_phon():
+    """Test the get_loudness_level_phon method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     # Get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -197,10 +204,11 @@ def test_loudness_iso_532_1_stationary_get_loudness_level_phon():
 
     loudness_level_phon = loudness_computer.get_loudness_level_phon()
     assert type(loudness_level_phon) == np.float64
-    assert loudness_level_phon == pytest.approx(EXP_LOUDNESS_LEVEL_1)
+    assert loudness_level_phon == pytest.approx(EXP_LOUDNESS_LEVEL_FREE)
 
 
 def test_loudness_iso_532_1_stationary_get_specific_loudness():
+    """Test the get_specific_loudness method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     # Get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -247,6 +255,7 @@ def test_loudness_iso_532_1_stationary_get_specific_loudness():
 
 
 def test_loudness_iso_532_1_stationary__get_ouptut_parameter():
+    """Test the _get_output_parameter method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     # Get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -280,11 +289,11 @@ def test_loudness_iso_532_1_stationary__get_ouptut_parameter():
 
     param = loudness_computer._get_output_parameter(0, LOUDNESS_SONE_ID)
     assert type(param) == np.float64
-    assert param == pytest.approx(EXP_LOUDNESS_1)
+    assert param == pytest.approx(EXP_LOUDNESS_FREE)
 
     param = loudness_computer._get_output_parameter(0, LOUDNESS_LEVEL_PHON_ID)
     assert type(param) == np.float64
-    assert param == pytest.approx(EXP_LOUDNESS_LEVEL_1)
+    assert param == pytest.approx(EXP_LOUDNESS_LEVEL_FREE)
 
     param = loudness_computer._get_output_parameter(0, SPECIFIC_LOUDNESS_ID)
     assert type(param) == np.ndarray
@@ -319,6 +328,7 @@ def test_loudness_iso_532_1_stationary__get_ouptut_parameter():
 
 
 def test_loudness_iso_532_1_stationary_get_bark_band_indexes():
+    """Test the _get_bark_band_indexes method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     # Get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -361,6 +371,7 @@ def test_loudness_iso_532_1_stationary_get_bark_band_indexes():
 
 
 def test_loudness_iso_532_1_stationary_get_bark_band_frequencies():
+    """Test the get_bark_band_frequencies method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     # Get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -381,6 +392,7 @@ def test_loudness_iso_532_1_stationary_get_bark_band_frequencies():
 
 
 def test_loudness_iso_532_1_stationary_get_output_as_nparray_from_fields_container():
+    """Test the get_output_as_nparray method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     # Get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -409,10 +421,10 @@ def test_loudness_iso_532_1_stationary_get_output_as_nparray_from_fields_contain
     ) = loudness_computer.get_output_as_nparray()
     assert type(loudness_sone) == np.ndarray
     assert len(loudness_sone) == 1
-    assert loudness_sone[0] == pytest.approx(EXP_LOUDNESS_1)
+    assert loudness_sone[0] == pytest.approx(EXP_LOUDNESS_FREE)
     assert type(loudness_level_phon) == np.ndarray
     assert len(loudness_level_phon) == 1
-    assert loudness_level_phon[0] == pytest.approx(EXP_LOUDNESS_LEVEL_1)
+    assert loudness_level_phon[0] == pytest.approx(EXP_LOUDNESS_LEVEL_FREE)
     assert type(specific_loudness) == np.ndarray
     assert len(specific_loudness) == 240
     assert specific_loudness[0] == pytest.approx(0.0)
@@ -421,6 +433,7 @@ def test_loudness_iso_532_1_stationary_get_output_as_nparray_from_fields_contain
 
 
 def test_loudness_iso_532_1_stationary_get_output_as_nparray_from_field():
+    """Test the get_output_as_nparray method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     # Get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -429,6 +442,8 @@ def test_loudness_iso_532_1_stationary_get_output_as_nparray_from_field():
 
     # Set signal
     loudness_computer.signal = fc[0]
+    loudness_computer.field_type = "Free"
+
     # Compute
     loudness_computer.process()
 
@@ -439,19 +454,33 @@ def test_loudness_iso_532_1_stationary_get_output_as_nparray_from_field():
     ) = loudness_computer.get_output_as_nparray()
     assert type(loudness_sone) == np.ndarray
     assert len(loudness_sone) == 1
-    assert loudness_sone[0] == pytest.approx(EXP_LOUDNESS_1)
+    assert loudness_sone[0] == pytest.approx(EXP_LOUDNESS_FREE)
     assert type(loudness_level_phon) == np.ndarray
     assert len(loudness_level_phon) == 1
-    assert loudness_level_phon[0] == pytest.approx(EXP_LOUDNESS_LEVEL_1)
+    assert loudness_level_phon[0] == pytest.approx(EXP_LOUDNESS_LEVEL_FREE)
     assert type(specific_loudness) == np.ndarray
     assert len(specific_loudness) == 240
     assert specific_loudness[0] == pytest.approx(0.0)
     assert specific_loudness[9] == pytest.approx(EXP_SPECIFIC_LOUDNESS_1_9)
     assert specific_loudness[40] == pytest.approx(EXP_SPECIFIC_LOUDNESS_1_40)
 
+    loudness_computer.field_type = "Diffuse"
+
+    # Compute
+    loudness_computer.process()
+
+    (
+        loudness_sone,
+        loudness_level_phon,
+        specific_loudness,
+    ) = loudness_computer.get_output_as_nparray()
+    assert loudness_sone[0] == pytest.approx(EXP_LOUDNESS_DIFFUSE)
+    assert loudness_level_phon[0] == pytest.approx(EXP_LOUDNESS_LEVEL_DIFFUSE)
+
 
 @patch("matplotlib.pyplot.show")
 def test_loudness_iso_532_1_stationary_plot_from_fields_container(mock_show):
+    """Test the plot method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     # Get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -490,6 +519,7 @@ def test_loudness_iso_532_1_stationary_plot_from_fields_container(mock_show):
 
 @patch("matplotlib.pyplot.show")
 def test_loudness_iso_532_1_stationary_plot_from_field(mock_show):
+    """Test the plot method of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     # Get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -506,6 +536,7 @@ def test_loudness_iso_532_1_stationary_plot_from_field(mock_show):
 
 
 def test_loudness_iso_532_1_stationary_set_get_signal():
+    """Test the signal property of the LoudnessISO532_1_Stationary class."""
     loudness_computer = LoudnessISO532_1_Stationary()
     fc = FieldsContainer()
     fc.labels = ["channel"]
@@ -519,3 +550,26 @@ def test_loudness_iso_532_1_stationary_set_get_signal():
     assert fc_from_get.name == "testField"
     assert len(fc_from_get) == 1
     assert fc_from_get[0].data[0, 2] == 42
+
+
+def test_loudness_iso_532_1_stationary_set_get_field_type():
+    """Test the field_type property of the LoudnessISO532_1_Stationary class."""
+    loudness_computer = LoudnessISO532_1_Stationary()
+
+    # Set value
+    loudness_computer.field_type = "Diffuse"
+    assert loudness_computer.field_type == "Diffuse"
+
+    # Check case insensitivity
+    loudness_computer.field_type = "diffuse"
+    assert loudness_computer.field_type == "diffuse"
+
+    loudness_computer.field_type = "DIFFUSE"
+    assert loudness_computer.field_type == "DIFFUSE"
+
+    # Set invalid value
+    with pytest.raises(
+        PyAnsysSoundException,
+        match='Invalid field type "Invalid". Available options are "Free" and "Diffuse".',
+    ):
+        loudness_computer.field_type = "Invalid"

--- a/tests/tests_psychoacoustics/test_psychoacoustics_loudness_iso_532_1_time_varying.py
+++ b/tests/tests_psychoacoustics/test_psychoacoustics_loudness_iso_532_1_time_varying.py
@@ -32,11 +32,13 @@ from ansys.sound.core.signal_utilities import LoadWav
 
 
 def test_loudness_iso_532_1_time_varying_instantiation():
+    """Test the instantiation of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     assert time_varying_loudness_computer != None
 
 
 def test_loudness_iso_532_1_time_varying_process():
+    """Test the process method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
 
     # no signal -> error 1
@@ -65,6 +67,7 @@ def test_loudness_iso_532_1_time_varying_process():
 
 
 def test_loudness_iso_532_1_time_varying_get_output():
+    """Test the get_output method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -96,6 +99,7 @@ def test_loudness_iso_532_1_time_varying_get_output():
 
 
 def test_loudness_iso_532_1_time_varying_get_output_as_nparray_from_field_container():
+    """Test the get_output_as_nparray method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -144,6 +148,7 @@ def test_loudness_iso_532_1_time_varying_get_output_as_nparray_from_field_contai
 
 
 def test_loudness_iso_532_1_time_varying_get_output_as_nparray_from_field():
+    """Test the get_output_as_nparray method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -152,6 +157,8 @@ def test_loudness_iso_532_1_time_varying_get_output_as_nparray_from_field():
 
     # set signal
     time_varying_loudness_computer.signal = fc[0]
+    time_varying_loudness_computer.field_type = "Free"
+
     # compute
     time_varying_loudness_computer.process()
 
@@ -186,8 +193,20 @@ def test_loudness_iso_532_1_time_varying_get_output_as_nparray_from_field():
     assert len(L10) == 1
     assert L10[0] == pytest.approx(94.63481140136719)
 
+    time_varying_loudness_computer.field_type = "Diffuse"
+
+    # compute
+    time_varying_loudness_computer.process()
+
+    _, N5, N10, _, L5, L10 = time_varying_loudness_computer.get_output_as_nparray()
+    assert N5[0] == pytest.approx(47.87789)
+    assert N10[0] == pytest.approx(46.89662)
+    assert L5[0] == pytest.approx(95.81287)
+    assert L10[0] == pytest.approx(95.51412)
+
 
 def test_loudness_iso_532_1_time_varying_get_loudness_vs_time_sone():
+    """Test the get_loudness_sone_vs_time method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -211,6 +230,7 @@ def test_loudness_iso_532_1_time_varying_get_loudness_vs_time_sone():
 
 
 def test_loudness_iso_532_1_time_varying_get_loudness_vs_time_sone_from_multichannel_fc():
+    """Test the get_loudness_sone_vs_time method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_white_noise_in_container)
@@ -231,6 +251,7 @@ def test_loudness_iso_532_1_time_varying_get_loudness_vs_time_sone_from_multicha
 
 
 def test_loudness_iso_532_1_time_varying_get_loudness_vs_time_phon():
+    """Test the get_loudness_level_phon_vs_time method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -254,6 +275,7 @@ def test_loudness_iso_532_1_time_varying_get_loudness_vs_time_phon():
 
 
 def test_loudness_iso_532_1_time_varying_get_loudness_vs_time_from_multichannel_fc():
+    """Test the get_loudness_level_phon_vs_time method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_white_noise_in_container)
@@ -274,6 +296,7 @@ def test_loudness_iso_532_1_time_varying_get_loudness_vs_time_from_multichannel_
 
 
 def test_loudness_iso_532_1_time_varying_get_N5():
+    """Test the get_N5_sone method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -300,6 +323,7 @@ def test_loudness_iso_532_1_time_varying_get_N5():
 
 
 def test_loudness_iso_532_1_time_varying_get_N5_from_field():
+    """Test the get_N5_sone method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -324,6 +348,7 @@ def test_loudness_iso_532_1_time_varying_get_N5_from_field():
 
 
 def test_loudness_iso_532_1_time_varying_get_N10():
+    """Test the get_N10_sone method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -343,6 +368,7 @@ def test_loudness_iso_532_1_time_varying_get_N10():
 
 
 def test_loudness_iso_532_1_time_varying_get_N10_from_field():
+    """Test the get_N10_sone method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -359,6 +385,7 @@ def test_loudness_iso_532_1_time_varying_get_N10_from_field():
 
 
 def test_loudness_iso_532_1_time_varying_get_L5():
+    """Test the get_L5_phon method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -378,6 +405,7 @@ def test_loudness_iso_532_1_time_varying_get_L5():
 
 
 def test_loudness_iso_532_1_time_varying_get_L5_from_field():
+    """Test the get_L5_phon method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -394,6 +422,7 @@ def test_loudness_iso_532_1_time_varying_get_L5_from_field():
 
 
 def test_loudness_iso_532_1_time_varying_get_L10():
+    """Test the get_L10_phon method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -413,6 +442,7 @@ def test_loudness_iso_532_1_time_varying_get_L10():
 
 
 def test_loudness_iso_532_1_time_varying_get_L10_from_field():
+    """Test the get_L10_phon method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -429,6 +459,7 @@ def test_loudness_iso_532_1_time_varying_get_L10_from_field():
 
 
 def test_loudness_iso_532_1_time_varying_get_time_scale():
+    """Test the get_time_scale method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -453,6 +484,7 @@ def test_loudness_iso_532_1_time_varying_get_time_scale():
 
 @patch("matplotlib.pyplot.show")
 def test_loudness_iso_532_1_time_varying_plot_from_field_container(mock_show):
+    """Test the plot method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
 
     # Load a signal
@@ -492,6 +524,7 @@ def test_loudness_iso_532_1_time_varying_plot_from_field_container(mock_show):
 
 @patch("matplotlib.pyplot.show")
 def test_loudness_iso_532_1_time_varying_plot_from_field(mock_show):
+    """Test the plot method of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     # get a signal
     wav_loader = LoadWav(pytest.data_path_flute_in_container)
@@ -508,6 +541,7 @@ def test_loudness_iso_532_1_time_varying_plot_from_field(mock_show):
 
 
 def test_loudness_iso_532_1_time_varying_set_get_signal():
+    """Test the set and get signal methods of the LoudnessISO532_1_TimeVarying class."""
     time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
     fc = FieldsContainer()
     fc.labels = ["channel"]
@@ -521,3 +555,26 @@ def test_loudness_iso_532_1_time_varying_set_get_signal():
     assert fc_from_get.name == "testField"
     assert len(fc_from_get) == 1
     assert fc_from_get[0].data[0, 2] == 42
+
+
+def test_loudness_iso_532_1_time_varying_set_get_field_type():
+    """Test the field_type property of the LoudnessISO532_1_TimeVarying class."""
+    time_varying_loudness_computer = LoudnessISO532_1_TimeVarying()
+
+    # Set value
+    time_varying_loudness_computer.field_type = "Diffuse"
+    assert time_varying_loudness_computer.field_type == "Diffuse"
+
+    # Check case insensitivity
+    time_varying_loudness_computer.field_type = "diffuse"
+    assert time_varying_loudness_computer.field_type == "diffuse"
+
+    time_varying_loudness_computer.field_type = "DIFFUSE"
+    assert time_varying_loudness_computer.field_type == "DIFFUSE"
+
+    # Set invalid value
+    with pytest.raises(
+        PyAnsysSoundException,
+        match='Invalid field type "Invalid". Available options are "Free" and "Diffuse".',
+    ):
+        time_varying_loudness_computer.field_type = "Invalid"

--- a/tests/tests_psychoacoustics/test_psychoacoustics_sharpness_din_45692.py
+++ b/tests/tests_psychoacoustics/test_psychoacoustics_sharpness_din_45692.py
@@ -28,8 +28,8 @@ from ansys.sound.core._pyansys_sound import PyAnsysSoundException, PyAnsysSoundW
 from ansys.sound.core.psychoacoustics import SharpnessDIN45692
 from ansys.sound.core.signal_utilities import LoadWav
 
-EXP_MAX_SHARPNESS_FREE = 1.216734
-EXP_MAX_SHARPNESS_DIFFUSE = 1.225831
+EXP_SHARPNESS_FREE = 1.216734
+EXP_SHARPNESS_DIFFUSE = 1.225831
 
 EXP_STR_DEFAULT = (
     "SharpnessDIN45692 object\nData:\n\tSignal name: Not set\nSharpness: Not processed"
@@ -71,6 +71,13 @@ def test_sharpness_din_45692_properties():
 
     sharpness_obj.field_type = "Diffuse"
     assert sharpness_obj.field_type == "Diffuse"
+
+    # Check case insensitivity
+    sharpness_obj.field_type = "diffuse"
+    assert sharpness_obj.field_type == "diffuse"
+
+    sharpness_obj.field_type = "DIFFUSE"
+    assert sharpness_obj.field_type == "DIFFUSE"
 
 
 def test_sharpness_din_45692_properties_exceptions():
@@ -132,13 +139,13 @@ def test_sharpness_din_45692_get_output():
     sharpness_obj.process()
 
     sharpness = sharpness_obj.get_output()
-    assert sharpness == pytest.approx(EXP_MAX_SHARPNESS_FREE)
+    assert sharpness == pytest.approx(EXP_SHARPNESS_FREE)
 
     sharpness_obj.field_type = "Diffuse"
     sharpness_obj.process()
 
     sharpness = sharpness_obj.get_output()
-    assert sharpness == pytest.approx(EXP_MAX_SHARPNESS_DIFFUSE)
+    assert sharpness == pytest.approx(EXP_SHARPNESS_DIFFUSE)
 
 
 def test_sharpness_din_45692_get_output_warning():
@@ -174,13 +181,13 @@ def test_sharpness_din_45692_get_output_as_nparray():
     sharpness_obj.process()
 
     sharpness = sharpness_obj.get_output_as_nparray()
-    assert sharpness[0] == pytest.approx(EXP_MAX_SHARPNESS_FREE)
+    assert sharpness[0] == pytest.approx(EXP_SHARPNESS_FREE)
 
     sharpness_obj.field_type = "Diffuse"
     sharpness_obj.process()
 
     sharpness = sharpness_obj.get_output_as_nparray()
-    assert sharpness[0] == pytest.approx(EXP_MAX_SHARPNESS_DIFFUSE)
+    assert sharpness[0] == pytest.approx(EXP_SHARPNESS_DIFFUSE)
 
 
 def test_sharpness_din_45692_get_sharpness():
@@ -197,10 +204,10 @@ def test_sharpness_din_45692_get_sharpness():
     sharpness_obj.process()
 
     sharpness = sharpness_obj.get_sharpness()
-    assert sharpness == pytest.approx(EXP_MAX_SHARPNESS_FREE)
+    assert sharpness == pytest.approx(EXP_SHARPNESS_FREE)
 
     sharpness_obj.field_type = "Diffuse"
     sharpness_obj.process()
 
     sharpness = sharpness_obj.get_sharpness()
-    assert sharpness == pytest.approx(EXP_MAX_SHARPNESS_DIFFUSE)
+    assert sharpness == pytest.approx(EXP_SHARPNESS_DIFFUSE)


### PR DESCRIPTION
Add field type in loudness ISO532-1 (stationary/time-varying)
Adjust tests accordingly
(Also fix a variable name typo in sharpness DIN45692 tests)