### PR TITLE
fix: apply the same PSD parameters for TNR/PR calculation as in SAS

### DIFF
--- a/doc/changelog.d/224.fixed.md
+++ b/doc/changelog.d/224.fixed.md
@@ -1,0 +1,1 @@
+fix: apply the same PSD parameters for TNR/PR calculation as in SAS

--- a/examples/006_calculate_PR_and_TNR.py
+++ b/examples/006_calculate_PR_and_TNR.py
@@ -154,7 +154,7 @@ flute_signal = wav_loader.get_output()[0]
 # %%
 # Create a PowerSpectralDensity object, set its input signal and parameters, and compute the PSD.
 psd_object = PowerSpectralDensity(
-    flute_signal, fft_size=8192, window_type="HANN", window_length=8192, overlap=0.8
+    flute_signal, fft_size=32768, window_type="HANN", window_length=32768, overlap=0.5
 )
 psd_object.process()
 


### PR DESCRIPTION
Apply the same PSD parameters for TNR/PR calculation as in SAS