### PR TITLE
fix: avoid the usage of the "egg" concept

### DIFF
--- a/doc/changelog.d/227.fixed.md
+++ b/doc/changelog.d/227.fixed.md
@@ -1,0 +1,1 @@
+fix: avoid the usage of the "egg" concept

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "ansys-dpf-core@git+https://github.com/ansys/pydpf-core#egg=master",
+    "ansys-dpf-core@git+https://github.com/ansys/pydpf-core",
     "matplotlib>=3.8.2,<4",
     "platformdirs>=3.6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "ansys-dpf-core@git+https://github.com/ansys/pydpf-core",
+    "ansys-dpf-core@git+https://github.com/ansys/pydpf-core.git",
     "matplotlib>=3.8.2,<4",
     "platformdirs>=3.6.0",
 ]


### PR DESCRIPTION
This is unnecessary and leads to issues when installing together with other libraries