### PR TITLE
fix: Explicitly add requests package to project dependencies

### DIFF
--- a/doc/changelog.d/231.fixed.md
+++ b/doc/changelog.d/231.fixed.md
@@ -1,0 +1,1 @@
+fix: Explicitly add requests package to project dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "ansys-dpf-core@git+https://github.com/ansys/pydpf-core.git",
     "matplotlib>=3.8.2,<4",
     "platformdirs>=3.6.0",
+    "requests>=2.30.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Add the package `requests` in the project dependencies, because it is necessary in module `download.py`
It used to be included through the `ansys-dpf-core`, and then `google-api-core`, packages, but it seems it is no longer the case