### PR TITLE
fix: Wrong unit for specific loudness and specific roughness in documentation

### DIFF
--- a/doc/changelog.d/232.fixed.md
+++ b/doc/changelog.d/232.fixed.md
@@ -1,0 +1,1 @@
+fix: Wrong unit for specific loudness and specific roughness in documentation

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
@@ -123,7 +123,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
 
             -   Second element (float) is the loudness level in phon.
 
-            -   Third element (field) is the specific loudness in sone.
+            -   Third element (field) is the specific loudness in sone/Bark.
         """
         if self._output == None:
             warnings.warn(
@@ -145,7 +145,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
 
             -   Second element is the loudness level in phon.
 
-            -   Third element is the specific loudness in sone.
+            -   Third element is the specific loudness in sone/Bark.
 
             -   Fourth element is the Bark band indexes, in Bark.
         """
@@ -187,7 +187,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
         Returns
         -------
         numpy.ndarray
-            Specific loudness array in sone.
+            Specific loudness array in sone/Bark.
         """
         return self.get_output_as_nparray()[2]
 
@@ -222,7 +222,7 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
     def plot(self):
         """Plot the specific loudness.
 
-        This method creates a figure window that displays the specific loudness in sone as a
+        This method creates a figure window that displays the specific loudness in sone/Bark as a
         function of the Bark band index.
         """
         if self._output == None:
@@ -237,6 +237,6 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
         plt.plot(bark_band_indexes, specific_loudness)
         plt.title("Specific loudness")
         plt.xlabel("Bark band index")
-        plt.ylabel("N' (sone)")
+        plt.ylabel("N' (sone/Bark)")
         plt.grid(True)
         plt.show()

--- a/src/ansys/sound/core/psychoacoustics/roughness.py
+++ b/src/ansys/sound/core/psychoacoustics/roughness.py
@@ -110,7 +110,7 @@ class Roughness(PsychoacousticsParent):
             -   First element (float) is the overall roughness in asper.
 
             -   Second element (Field) is the specific roughness, that is, the roughness in each
-                Bark band, in asper.
+                Bark band, in asper/Bark.
 
             -   Third element (Field) is the roughness over time, in asper.
         """
@@ -132,7 +132,7 @@ class Roughness(PsychoacousticsParent):
             -   First element is the overall roughness in asper.
 
             -   Second element is the specific roughness, that is, the roughness in each Bark band,
-                in asper.
+                in asper/Bark.
 
             -   Third element is the Bark band indexes at which the specific roughness is defined,
                 in Bark.
@@ -165,12 +165,12 @@ class Roughness(PsychoacousticsParent):
         return float(self.get_output_as_nparray()[0])
 
     def get_specific_roughness(self) -> np.ndarray:
-        """Get the specific roughness in asper.
+        """Get the specific roughness in asper/Bark.
 
         Returns
         -------
         numpy.ndarray
-            Specific roughness, that is, the roughness in each Bark band, in asper.
+            Specific roughness, that is, the roughness in each Bark band, in asper/Bark.
         """
         return self.get_output_as_nparray()[1]
 
@@ -243,13 +243,13 @@ class Roughness(PsychoacousticsParent):
         axes[0].plot(bark_band_indexes, specific_roughness)
         axes[0].set_title("Specific roughness")
         axes[0].set_xlabel("z (Bark)")
-        axes[0].set_ylabel("R' (asper)")
+        axes[0].set_ylabel("R' (asper/Bark)")
         axes[0].grid(True)
 
         axes[1].plot(time_scale, roughness_over_time)
         axes[1].set_title("Roughness over time")
         axes[1].set_xlabel("Time (s)")
-        axes[1].set_ylabel("R (asper)")
+        axes[1].set_ylabel("R (asper/Bark)")
         axes[1].grid(True)
 
         plt.tight_layout()

--- a/src/ansys/sound/core/psychoacoustics/tonality_din_45681.py
+++ b/src/ansys/sound/core/psychoacoustics/tonality_din_45681.py
@@ -41,7 +41,7 @@ class TonalityDIN45681(PsychoacousticsParent):
     """
 
     def __init__(self, signal: Field = None, window_length: float = 3.0, overlap: float = 0.0):
-        """Create a ``TonalityDIN45681`` object.
+        """Class instantiation takes the following parameters.
 
         Parameters
         ----------
@@ -199,9 +199,6 @@ class TonalityDIN45681(PsychoacousticsParent):
             Seventh element is the DIN 45681 tonal adjustment Kt over time, in dB.
 
             Eighth element is the time scale, in s.
-
-            Ninth element is the DIN 45681 tonality details (individual tone data for each
-            spectrum).
         """
         output = self.get_output()
 
@@ -210,7 +207,6 @@ class TonalityDIN45681(PsychoacousticsParent):
                 np.nan,
                 np.nan,
                 np.nan,
-                np.array([]),
                 np.array([]),
                 np.array([]),
                 np.array([]),
@@ -227,7 +223,6 @@ class TonalityDIN45681(PsychoacousticsParent):
             np.array(output[5].data),
             np.array(output[6].data),
             np.array(output[3].time_freq_support.time_frequencies.data),
-            np.array(output[7]),
         )
 
     def get_mean_difference(self) -> float:

--- a/src/ansys/sound/core/spectral_processing/power_spectral_density.py
+++ b/src/ansys/sound/core/spectral_processing/power_spectral_density.py
@@ -56,8 +56,7 @@ class PowerSpectralDensity(SpectralProcessingParent):
         signal : Field
             Mono signal as a DPF field on which to compute the PSD.
         fft_size : int, default: 2048
-            Number of FFT points to use for the PSD estimate.
-            Use a power of 2 for better performance.
+            Number of FFT points to use for the PSD estimate. Must be a power of 2.
         window_type : str, default: 'HANN'
             Window type used for the PSD computation. Options are ``'BARTLETT'``, ``'BLACKMAN'``,
             ``'BLACKMANHARRIS'``, ``'HAMMING'``, ``'HANN'``, ``'KAISER'``, and ``'RECTANGULAR'``.
@@ -94,14 +93,23 @@ class PowerSpectralDensity(SpectralProcessingParent):
 
     @property
     def fft_size(self) -> int:
-        """Number of FFT points."""
+        """Number of FFT points.
+
+        Must be a power of 2.
+        """
         return self.__fft_size
 
     @fft_size.setter
     def fft_size(self, value: int):
         """Set FFT size."""
+        # Check if the FFT size is positive.
         if value < 0:
             raise PyAnsysSoundException("FFT size must be positive.")
+
+        # Check if the FFT size is a power of 2.
+        if bin(value).count("1") != 1:
+            raise PyAnsysSoundException("FFT size must be a power of 2.")
+
         self.__fft_size = value
 
     @property

--- a/tests/tests_psychoacoustics/test_psychoacoustics_tonality_din_45681.py
+++ b/tests/tests_psychoacoustics/test_psychoacoustics_tonality_din_45681.py
@@ -168,7 +168,7 @@ def test_tonality_din45681_get_output_as_nparray():
     tonality = TonalityDIN45681(signal=fc[0])
     tonality.process()
 
-    DL, U, Kt, DLj, Uj, fTj, Ktj, time, _ = tonality.get_output_as_nparray()
+    DL, U, Kt, DLj, Uj, fTj, Ktj, time = tonality.get_output_as_nparray()
     assert DL == pytest.approx(EXP_DL)
     assert U == pytest.approx(EXP_U)
     assert Kt == pytest.approx(EXP_KT)
@@ -187,7 +187,7 @@ def test_tonality_din45681_get_output_as_nparray_unprocessed():
         PyAnsysSoundWarning,
         match="Output is not processed yet. Use the ``TonalityDIN45681.process\\(\\)`` method.",
     ):
-        DL, U, Kt, DLj, Uj, fTj, Ktj, time, _ = tonality.get_output_as_nparray()
+        DL, U, Kt, DLj, Uj, fTj, Ktj, time = tonality.get_output_as_nparray()
     assert np.isnan(DL)
     assert np.isnan(Kt)
     assert np.isnan(U)

--- a/tests/tests_spectral_processing/test_power_spectral_density.py
+++ b/tests/tests_spectral_processing/test_power_spectral_density.py
@@ -100,6 +100,11 @@ def test_exception():
 
     with pytest.raises(PyAnsysSoundException) as record:
         psd = PowerSpectralDensity(Field())
+        psd.fft_size = 23
+    assert record.value.args[0] == "FFT size must be a power of 2."
+
+    with pytest.raises(PyAnsysSoundException) as record:
+        psd = PowerSpectralDensity(Field())
         psd.overlap = -1
     assert (
         record.value.args[0]


### PR DESCRIPTION
Specific loudness' and specific roughness' units were wrongly indicating sone and asper, respectively.
They were fixed to their correct units: sone/Bark, and asper/Bark

Also added power-of-2 requirement for FFT size in `PowerSpectralDensity` and corresponding check

(Also removed DIN45681 calculation details from method `get_output_as_nparray` method as it was unusable as such. The reason is these details are stored in a `GenericDataContainerCollection`, and there is no point outputting these as numpy arrays)