### PR TITLE
fix: update autodenoise test reference values following DPF Sound DLL update

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -141,9 +141,6 @@ jobs:
           pip install --upgrade build wheel
           pip install .[tests]
 
-      - name: "Install Tcl/Tk"
-        run: sudo apt-get install tk8.6-dev
-
       - name: "Login to GitHub Container Registry"
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -141,6 +141,9 @@ jobs:
           pip install --upgrade build wheel
           pip install .[tests]
 
+      - name: "Install Tcl/Tk"
+        run: sudo apt-get install tk8.6-dev
+
       - name: "Login to GitHub Container Registry"
         uses: docker/login-action@v3
         with:

--- a/doc/changelog.d/271.fixed.md
+++ b/doc/changelog.d/271.fixed.md
@@ -1,0 +1,1 @@
+fix: update autodenoise test reference values following DPF Sound DLL update

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_2.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_2.py
@@ -37,6 +37,7 @@ RECORDING_MIC = "Mic"
 RECORDING_HEAD = "Head"
 
 
+
 class LoudnessISO532_2(PsychoacousticsParent):
     """Computes ISO 532-2:2017 loudness.
 

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_2.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_2.py
@@ -245,8 +245,7 @@ class LoudnessISO532_2(PsychoacousticsParent):
             -   Sixth element: monaural specific loudness in sone/Cam at each ear, as a function of
                 the ERB center frequency.
 
-            -   Seventh element: center frequencies in Hz of the equivalent rectangular
-                bandwidths (ERB), where specific loudness is defined.
+            -   Seventh element: ERBn-number scale in Cam, where specific loudness is defined.
         """
         output = self.get_output()
 
@@ -359,7 +358,7 @@ class LoudnessISO532_2(PsychoacousticsParent):
         numpy.ndarray
             Array of ERB center frequencies in Hz.
         """
-        return self.get_output_as_nparray()[6]
+        return (pow(10, self.get_erbn_numbers() / 21.366) - 1) / 0.004368
 
     def get_erbn_numbers(self) -> np.ndarray:
         """Get the ERBn-number scale in Cam.
@@ -372,7 +371,7 @@ class LoudnessISO532_2(PsychoacousticsParent):
         numpy.ndarray
             ERBn-number scale in Cam.
         """
-        return 21.366 * np.log10(0.004368 * self.get_erb_center_frequencies() + 1)
+        return self.get_output_as_nparray()[6]
 
     def plot(self):
         """Plot the binaural specific loudness.

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_2.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_2.py
@@ -37,7 +37,6 @@ RECORDING_MIC = "Mic"
 RECORDING_HEAD = "Head"
 
 
-
 class LoudnessISO532_2(PsychoacousticsParent):
     """Computes ISO 532-2:2017 loudness.
 

--- a/tests/tests_psychoacoustics/test_psychoacoustics_loudness_iso_532_2.py
+++ b/tests/tests_psychoacoustics/test_psychoacoustics_loudness_iso_532_2.py
@@ -396,16 +396,16 @@ def test_loudness_iso_532_2_get_output_as_nparray():
 
     wav_loader = LoadWav(pytest.data_path_flute_nonUnitaryCalib_in_container)
     wav_loader.process()
-    fc = wav_loader.get_output()
+    ERBn = wav_loader.get_output()
 
-    loudness_computer.signal = fc[0]
+    loudness_computer.signal = ERBn[0]
 
     # Loudness not calculated yet -> warning
     with pytest.warns(
         PyAnsysSoundWarning,
         match=("Output is not processed yet. " "Use the `LoudnessISO532_2.process\\(\\)` method."),
     ):
-        N_bin, LN_bin, N_mon, LN_mon, Nprime_bin, Nprime_mon, fc = (
+        N_bin, LN_bin, N_mon, LN_mon, Nprime_bin, Nprime_mon, ERBn = (
             loudness_computer.get_output_as_nparray()
         )
     assert np.isnan(N_bin)
@@ -414,11 +414,11 @@ def test_loudness_iso_532_2_get_output_as_nparray():
     assert len(LN_mon) == 0
     assert len(Nprime_bin) == 0
     assert len(Nprime_mon) == 0
-    assert len(fc) == 0
+    assert len(ERBn) == 0
 
     loudness_computer.process()
 
-    N_bin, LN_bin, N_mon, LN_mon, Nprime_bin, Nprime_mon, fc = (
+    N_bin, LN_bin, N_mon, LN_mon, Nprime_bin, Nprime_mon, ERBn = (
         loudness_computer.get_output_as_nparray()
     )
     assert N_bin == pytest.approx(EXP_BIN_LOUDNESS_DIOTIC_FREE_MIC)
@@ -435,10 +435,10 @@ def test_loudness_iso_532_2_get_output_as_nparray():
     assert Nprime_mon[0] == pytest.approx(EXP_MON_SPECIFIC_LOUDNESS_DIOTIC_FREE_MIC_0)
     assert Nprime_mon[45] == pytest.approx(EXP_MON_SPECIFIC_LOUDNESS_DIOTIC_FREE_MIC_45)
     assert Nprime_mon[98] == pytest.approx(EXP_MON_SPECIFIC_LOUDNESS_DIOTIC_FREE_MIC_98)
-    assert len(fc) == 372
-    assert fc[0] == pytest.approx(EXP_FREQ_0)
-    assert fc[45] == pytest.approx(EXP_FREQ_45)
-    assert fc[98] == pytest.approx(EXP_FREQ_98)
+    assert len(ERBn) == 372
+    assert ERBn[0] == pytest.approx(EXP_ERB_0)
+    assert ERBn[45] == pytest.approx(EXP_ERB_45)
+    assert ERBn[98] == pytest.approx(EXP_ERB_98)
 
 
 def test_loudness_iso_532_2_get_binaural_loudness_sone():

--- a/tests/tests_psychoacoustics/test_psychoacoustics_sharpness_din_45692.py
+++ b/tests/tests_psychoacoustics/test_psychoacoustics_sharpness_din_45692.py
@@ -28,13 +28,13 @@ from ansys.sound.core._pyansys_sound import PyAnsysSoundException, PyAnsysSoundW
 from ansys.sound.core.psychoacoustics import SharpnessDIN45692
 from ansys.sound.core.signal_utilities import LoadWav
 
-EXP_SHARPNESS_FREE = 1.216734
-EXP_SHARPNESS_DIFFUSE = 1.225831
+EXP_SHARPNESS_FREE = 1.212122
+EXP_SHARPNESS_DIFFUSE = 1.221786
 
 EXP_STR_DEFAULT = (
     "SharpnessDIN45692 object\nData:\n\tSignal name: Not set\nSharpness: Not processed"
 )
-EXP_STR = 'SharpnessDIN45692 object\nData:\n\tSignal name: "flute"\nSharpness: 1.22 acums'
+EXP_STR = 'SharpnessDIN45692 object\nData:\n\tSignal name: "flute"\nSharpness: 1.21 acums'
 
 
 def test_sharpness_din_45692_instantiation():

--- a/tests/tests_sound_composer/test_sound_composer_source_control_time.py
+++ b/tests/tests_sound_composer/test_sound_composer_source_control_time.py
@@ -29,7 +29,7 @@ from ansys.sound.core._pyansys_sound import PyAnsysSoundException
 from ansys.sound.core.signal_utilities.load_wav import LoadWav
 from ansys.sound.core.sound_composer import SourceControlTime
 
-EXP_STR_ALL_SET = "Unit: \nDuration: 20.6 s\nMin - max: 968.8 - 4821.3 "
+EXP_STR_ALL_SET = "Unit: rpm\nDuration: 20.6 s\nMin - max: 968.8 - 4821.3 rpm"
 EXP_STR_NOT_SET = "Not set"
 
 

--- a/tests/tests_xtract/test_xtract_denoiser_parameters.py
+++ b/tests/tests_xtract/test_xtract_denoiser_parameters.py
@@ -78,7 +78,7 @@ def test_xtract_denoiser_parameters_generate_noise_psd_from_automatic_estimation
     noise = noise_psd.data
 
     s = np.sum(noise)
-    assert s == pytest.approx(0.005321223133933017)
+    assert s == pytest.approx(0.0051941522299330245)
 
 
 def test_xtract_denoiser_parameters_generate_noise_psd_from_noise_samples():


### PR DESCRIPTION
Because of a DPF Sound bug (STFT last frame was previously present but not filled), a slight change in the DLL required a test's expected value to be updated.
Automatic noise estimation in Xtract is based on STFT, so this change affected expected values for Xtract denoiser

Unrelated:
- Adapted Loudness ISO 532-2 helper class (and test) following a recent change in DPF Sound where the specific loudness support is now the ERBn-number scale, as opposed to the corresponding center frequency previously (ADO PR #580847 )
- Adapted a `SourceControlTime` test following a DPF Sound improvement where non-SI units are now retrieved when using the `load_wav_sas` operator (ADO PR #583498)
- Adapted expected values for Sharpness DIN 45692 following a bug fix in SAS & DPF Sound (ADO PR #585881)