### PR TITLE
feat: connect_to_or_start_server now return the LicenseContext instead of storing it as a member of the server

### DIFF
--- a/examples/001_initialize_server_and_deal_with_license.py
+++ b/examples/001_initialize_server_and_deal_with_license.py
@@ -79,7 +79,7 @@ from ansys.sound.core.signal_utilities import LoadWav
 
 # Connect to a remote server or start a local server without using a LicenseContextManager
 print("Connecting to the server without using a LicenseContextManager")
-my_server = connect_to_or_start_server(use_license_context=False)
+my_server, my_license_context = connect_to_or_start_server(use_license_context=False)
 
 # Check if you are using a local or remote server
 has_local_server = dpf.server.has_local_server()
@@ -113,8 +113,8 @@ for i in range(5):
     )
 
 # %%
-# Disconnect (shut down) the server and release the license increment.
-print("Disconnecting from the server and releasing the license increment.")
+# Disconnect (shut down) the server.
+print("Disconnecting from the server.")
 my_server = None
 
 # %%
@@ -128,7 +128,7 @@ my_server = None
 
 # Connect to a remote server or start a local server using a LicenseContextManager
 print("Connecting to the server using a LicenseContextManager")
-my_server = connect_to_or_start_server(use_license_context=True)
+my_server, my_license_context = connect_to_or_start_server(use_license_context=True)
 
 # Execute the same and measure the execution time
 path_flute_wav = download_flute_wav(server=my_server)
@@ -150,3 +150,28 @@ for i in range(5):
 # You can see that the execution time is much faster when you use a LicenseContextManager.
 # This is because when a LicenseContactManager is not used, the license is checked out
 # each time you use a DPF Sound operator.
+
+# %%
+# You can release the license increment by deleting the LicenseContextManager object.
+print("Releasing the license increment by deleting the LicenseContextManager object.")
+my_license_context = None
+
+# %%
+# Now the LicenseContextManager has been deleted, any call to a PyAnsys Sound function will
+# again take the time to check out the license increment. Let us call the same function as before:
+now = datetime.datetime.now()
+wav_loader = LoadWav(path_flute_wav)
+wav_loader.process()
+fc_signal = wav_loader.get_output()
+later = datetime.datetime.now()
+execution_time = later - now
+print(
+    f"Elapsed time: "
+    f"{execution_time.seconds + execution_time.microseconds / 1e6}"
+    f" seconds",
+)
+
+# %%
+# Disconnect (shut down) the server and release the license increment.
+print("Disconnecting from the server and releasing the license increment.")
+my_server = None

--- a/examples/002_load_resample_amplify_write_wav_files.py
+++ b/examples/002_load_resample_amplify_write_wav_files.py
@@ -46,7 +46,7 @@ from ansys.sound.core.server_helpers import connect_to_or_start_server
 from ansys.sound.core.signal_utilities import ApplyGain, LoadWav, Resample, WriteWav
 
 # Connect to a remote server or start a local server
-server = connect_to_or_start_server(use_license_context=True)
+server, lic_context = connect_to_or_start_server(use_license_context=True)
 
 # %%
 # Load a signal

--- a/examples/003_compute_stft.py
+++ b/examples/003_compute_stft.py
@@ -48,7 +48,7 @@ from ansys.sound.core.spectrogram_processing import Istft, Stft
 # sphinx_gallery_end_ignore
 
 # Connect to a remote server or start a local server
-my_server = connect_to_or_start_server(use_license_context=True)
+my_server, lic_context = connect_to_or_start_server(use_license_context=True)
 
 # %%
 # Load a signal

--- a/examples/004_isolate_orders.py
+++ b/examples/004_isolate_orders.py
@@ -65,7 +65,7 @@ from ansys.sound.core.spectrogram_processing import IsolateOrders, Stft
 # sphinx_gallery_end_ignore
 
 # Connect to a remote or start a local server
-my_server = connect_to_or_start_server(use_license_context=True)
+my_server, lic_context = connect_to_or_start_server(use_license_context=True)
 
 
 # %%

--- a/examples/005_xtract_feature.py
+++ b/examples/005_xtract_feature.py
@@ -69,7 +69,7 @@ from ansys.sound.core.xtract import (
 # sphinx_gallery_end_ignore
 
 # Connect to a remote server or start a local server
-my_server = connect_to_or_start_server(use_license_context=True)
+my_server, lic_context = connect_to_or_start_server(use_license_context=True)
 
 
 # %%

--- a/examples/006_calculate_PR_and_TNR.py
+++ b/examples/006_calculate_PR_and_TNR.py
@@ -60,7 +60,7 @@ from ansys.sound.core.signal_utilities import LoadWav
 from ansys.sound.core.spectral_processing import PowerSpectralDensity
 
 # Connect to a remote server or start a local server.
-my_server = connect_to_or_start_server(use_license_context=True)
+my_server, lic_context = connect_to_or_start_server(use_license_context=True)
 
 # %%
 # Calculate TNR from a PSD

--- a/examples/007_calculate_psychoacoustic_indicators.py
+++ b/examples/007_calculate_psychoacoustic_indicators.py
@@ -80,7 +80,7 @@ from ansys.sound.core.server_helpers import connect_to_or_start_server
 from ansys.sound.core.signal_utilities import LoadWav
 
 # Connect to a remote DPF server or start a local DPF server.
-my_server = connect_to_or_start_server(use_license_context=True)
+my_server, lic_context = connect_to_or_start_server(use_license_context=True)
 
 
 # %%

--- a/examples/008_calculate_levels.py
+++ b/examples/008_calculate_levels.py
@@ -67,7 +67,7 @@ from ansys.sound.core.signal_utilities import LoadWav
 from ansys.sound.core.standard_levels import LevelOverTime, OverallLevel
 
 # Connect to a remote server or start a local server.
-my_server = connect_to_or_start_server(use_license_context=True)
+my_server, lic_context = connect_to_or_start_server(use_license_context=True)
 
 
 # %%

--- a/examples/009_calculate_tonality_indicators.py
+++ b/examples/009_calculate_tonality_indicators.py
@@ -64,7 +64,7 @@ from ansys.sound.core.spectrogram_processing.stft import Stft
 # sphinx_gallery_end_ignore
 
 # Connect to a remote server or start a local server.
-my_server = connect_to_or_start_server(use_license_context=True)
+my_server, lic_context = connect_to_or_start_server(use_license_context=True)
 
 # Load example data from a WAV file: flyover noise of an aircraft.
 path_aircraft_wav = download_aircraft10kHz_wav(server=my_server)

--- a/examples/010_sound_composer_load_project.py
+++ b/examples/010_sound_composer_load_project.py
@@ -66,7 +66,7 @@ from ansys.sound.core.spectrogram_processing import Stft
 # sphinx_gallery_end_ignore
 
 # Connect to a remote server or start a local server.
-my_server = connect_to_or_start_server(use_license_context=True)
+my_server, lic_context = connect_to_or_start_server(use_license_context=True)
 
 
 # %%

--- a/src/ansys/sound/core/server_helpers/_connect_to_or_start_server.py
+++ b/src/ansys/sound/core/server_helpers/_connect_to_or_start_server.py
@@ -64,9 +64,10 @@ def connect_to_or_start_server(
         PyAnsys Sound. Checking out the license increment improves performance if you are doing
         multiple calls to DPF Sound operators because they require licensing. This parameter
         can also be used to force check out before running a script when few DPF Sound license
-        increments are available. The license is checked in when the server object is deleted.
-        If a different license increment is required, set this parameter to True and set the
-        ``license_increment_name`` parameter to the name of the license increment to check out.
+        increments are available. The license is checked in when the LicenseContextManager object
+        is deleted. If a different license increment is required, set this parameter to True and
+        set the ``license_increment_name`` parameter to the name of the license increment to check
+        out.
     license_increment_name : str, default: "avrxp_snd_level1"
         Name of the license increment to check out. Only taken into account if use_license_context
         is True. The default value is ``avrxp_snd_level1``, which corresponds to the license
@@ -76,6 +77,9 @@ def connect_to_or_start_server(
     -------
     Any
         server : server.ServerBase
+        lic_context : LicenseContextManager. Is None if use_license_context is False. Otherwise,
+        it is a LicenseContextManager object, and should not be deleted until the end of the part
+        of your program which uses PyAnsys Sound.
     """
     # Collect the port to connect to the server
     port_in_env = os.environ.get("ANSRV_DPF_SOUND_PORT")
@@ -115,8 +119,4 @@ def connect_to_or_start_server(
     if use_license_context == True:
         lic_context = LicenseContextManager(license_increment_name, server=server)
 
-    # "attach" the license context to the server as a member so that they have the same
-    # life duration
-    server.license_context_manager = lic_context
-
-    return server
+    return server, lic_context

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def pytest_configure():
     # a docker or local configuration.
     # There are tests for the function connect_to_or_start_server that are independent from the
     # configuration. That's why we authorize the use of this function here.
-    server = connect_to_or_start_server(use_license_context=True)
+    server, lic_context = connect_to_or_start_server(use_license_context=True)
 
     ## Get the current directory of the conftest.py file
     base_dir = os.path.join(os.path.dirname(__file__), "data")


### PR DESCRIPTION
The function `connect_to_or_start_server` use to return the `server` object, and in thecase a license context is used, it is stored as a new member variable of server. It makes the job but hs a side effect: the dpf grpc process is not killed at the end of the python program.

In order to overcome this problem, the license context is now returned as a second output of `connect_to_or_start_server` and no more a member of  `server`.

This change modifies the prototype of `connect_to_or_start_server`, and the examples using this function have been updated too, as well as the `conftest` file.