### PR TITLE
feat: Use in-process server by default when using local server

### DIFF
--- a/doc/changelog.d/289.added.md
+++ b/doc/changelog.d/289.added.md
@@ -1,0 +1,1 @@
+feat: Use in-process server by default when using local server

--- a/doc/changelog.d/289.added.md
+++ b/doc/changelog.d/289.added.md
@@ -1,1 +1,0 @@
-feat: Use in-process server by default when using local server

--- a/doc/changelog.d/289.test.md
+++ b/doc/changelog.d/289.test.md
@@ -1,0 +1,1 @@
+Feat: use in-process server by default when using local server

--- a/examples/001_initialize_server_and_deal_with_license.py
+++ b/examples/001_initialize_server_and_deal_with_license.py
@@ -57,8 +57,6 @@ the PyDPF-Core documentation:
 # Load Ansys and other libraries.
 import datetime
 
-import ansys.dpf.core as dpf
-
 from ansys.sound.core.examples_helpers import download_flute_wav
 from ansys.sound.core.server_helpers import connect_to_or_start_server
 from ansys.sound.core.signal_utilities import LoadWav
@@ -82,11 +80,11 @@ print("Connecting to the server without using a LicenseContextManager")
 my_server = connect_to_or_start_server(use_license_context=False)
 
 # Check if you are using a local or remote server
-has_local_server = dpf.server.has_local_server()
-print(f"Local server: {has_local_server}")
+is_server_local = my_server.has_client()
+print(f"Local server: {is_server_local}")
 
 # If using a local server, display the path to the server
-if has_local_server == True:
+if is_server_local == True:
     print(f"Local server path (server variable): {my_server.ansys_path}")
 
 # %%

--- a/examples/001_initialize_server_and_deal_with_license.py
+++ b/examples/001_initialize_server_and_deal_with_license.py
@@ -80,7 +80,7 @@ print("Connecting to the server without using a LicenseContextManager")
 my_server = connect_to_or_start_server(use_license_context=False)
 
 # Check if you are using a local or remote server
-is_server_local = my_server.has_client()
+is_server_local = not my_server.has_client()
 print(f"Local server: {is_server_local}")
 
 # If using a local server, display the path to the server

--- a/src/ansys/sound/core/examples_helpers/download.py
+++ b/src/ansys/sound/core/examples_helpers/download.py
@@ -140,10 +140,12 @@ def _download_example_file_to_server_tmp_folder(filename, server=None):  # pragm
     try:
         # download file locally
         local_path = _download_file_in_local_tmp_folder(url, filename)
-        # upload file to DPF server,
-        # so that we are independent on the server configuration
-        server_path = upload_file_in_tmp_folder(file_path=local_path, server=server)
-        return server_path
+        if server.has_client():
+            # If the server has a client, then it is a remote server and we need to upload the file
+            # to the server's tmp folder.
+            return upload_file_in_tmp_folder(file_path=local_path, server=server)
+        # Otherwise, the server is a local server, and we can use the local path directly
+        return local_path
 
     except Exception as e:  # Generate exception
         raise RuntimeError(

--- a/src/ansys/sound/core/server_helpers/_connect_to_or_start_server.py
+++ b/src/ansys/sound/core/server_helpers/_connect_to_or_start_server.py
@@ -27,10 +27,8 @@ from typing import Optional, Union
 
 from ansys.dpf.core import (
     LicenseContextManager,
-    ServerConfig,
     connect_to_server,
     load_library,
-    server_factory,
     server_types,
     start_local_server,
 )
@@ -42,7 +40,6 @@ def connect_to_or_start_server(
     ansys_path: Optional[str] = None,
     use_license_context: Optional[bool] = False,
     license_increment_name: Optional[str] = "avrxp_snd_level1",
-    use_grpc: Optional[bool] = False,
 ) -> server_types.InProcessServer | server_types.GrpcServer:
     r"""Connect to or start a DPF server with the DPF Sound plugin loaded.
 
@@ -73,10 +70,6 @@ def connect_to_or_start_server(
         Name of the license increment to check out. Only taken into account if use_license_context
         is True. The default value is ``avrxp_snd_level1``, which corresponds to the license
         required by Ansys Sound Pro.
-    use_grpc : bool, default: False
-        If True, a gRPC server is started. If False, an in-process server is started, where the DPF
-        libraries are loaded directly into the Python process. This is overridden as True if either
-        ``ip`` or ``port`` is set, as a remote server connection is required.
 
     Returns
     -------
@@ -102,13 +95,7 @@ def connect_to_or_start_server(
         )
     else:  # pragma: no cover
         # Local server => start a local server
-        if use_grpc:
-            # gRPC server
-            config = ServerConfig(protocol=server_factory.CommunicationProtocols.gRPC, legacy=False)
-        else:
-            # In-process server
-            config = None
-        server = start_local_server(config=config, ansys_path=ansys_path, as_global=True)
+        server = start_local_server(ansys_path=ansys_path, as_global=True)
         full_path_dll = os.path.join(server.ansys_path, "Acoustics\\SAS\\ads\\")
 
     required_version = "8.0"

--- a/src/ansys/sound/core/server_helpers/_connect_to_or_start_server.py
+++ b/src/ansys/sound/core/server_helpers/_connect_to_or_start_server.py
@@ -23,7 +23,7 @@
 """Helpers to connect to or start a DPF server with the DPF Sound plugin."""
 
 import os
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 from ansys.dpf.core import (
     LicenseContextManager,
@@ -31,6 +31,7 @@ from ansys.dpf.core import (
     connect_to_server,
     load_library,
     server_factory,
+    server_types,
     start_local_server,
 )
 
@@ -41,7 +42,8 @@ def connect_to_or_start_server(
     ansys_path: Optional[str] = None,
     use_license_context: Optional[bool] = False,
     license_increment_name: Optional[str] = "avrxp_snd_level1",
-) -> Any:
+    use_grpc: Optional[bool] = False,
+) -> server_types.InProcessServer | server_types.GrpcServer:
     r"""Connect to or start a DPF server with the DPF Sound plugin loaded.
 
     .. note::
@@ -71,11 +73,15 @@ def connect_to_or_start_server(
         Name of the license increment to check out. Only taken into account if use_license_context
         is True. The default value is ``avrxp_snd_level1``, which corresponds to the license
         required by Ansys Sound Pro.
+    use_grpc : bool, default: False
+        If True, a gRPC server is started. If False, an in-process server is started, where the DPF
+        libraries are loaded directly into the Python process. This is overridden as True if either
+        ``ip`` or ``port`` is set, as a remote server connection is required.
 
     Returns
     -------
-    Any
-        server : server.ServerBase
+    server_types.InProcessServer | server_types.GrpcServer
+        Server object started or connected to.
     """
     # Collect the port to connect to the server
     port_in_env = os.environ.get("ANSRV_DPF_SOUND_PORT")
@@ -88,17 +94,21 @@ def connect_to_or_start_server(
     if ip is not None:
         connect_kwargs["ip"] = ip
 
-    # Decide whether we start a local server or a remote server
     full_path_dll = ""
     if len(list(connect_kwargs.keys())) > 0:
+        # Remote server => connect using gRPC
         server = connect_to_server(
             **connect_kwargs,
         )
     else:  # pragma: no cover
-        grpc_config = ServerConfig(
-            protocol=server_factory.CommunicationProtocols.gRPC, legacy=False
-        )
-        server = start_local_server(config=grpc_config, ansys_path=ansys_path, as_global=True)
+        # Local server => start a local server
+        if use_grpc:
+            # gRPC server
+            config = ServerConfig(protocol=server_factory.CommunicationProtocols.gRPC, legacy=False)
+        else:
+            # In-process server
+            config = None
+        server = start_local_server(config=config, ansys_path=ansys_path, as_global=True)
         full_path_dll = os.path.join(server.ansys_path, "Acoustics\\SAS\\ads\\")
 
     required_version = "8.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,165 +36,167 @@ def pytest_configure():
     # configuration. That's why we authorize the use of this function here.
     server = connect_to_or_start_server(use_license_context=True)
 
-    ## Get the current directory of the conftest.py file
+    # Use the conftest.py file's directory to set the base directory for the test data files.
     base_dir = os.path.join(os.path.dirname(__file__), "data")
+
+    def get_test_file_path(filename, base_dir, server):
+        # Set the local path to the test file.
+        local_path = os.path.join(base_dir, filename)
+
+        if server.has_client():
+            # If the server is a gRPC server, we need to upload the file to the server's temporary
+            # folder
+            return upload_file_in_tmp_folder(local_path, server=server)
+        # Otherwise, that is, if the server is an in-process server, we return the local path
+        return local_path
 
     ## Construct the paths of the different test files after uploading them on the server.
     # Audio samples
-    pytest.data_path_flute_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "flute.wav"), server=server
+    pytest.data_path_flute_in_container = get_test_file_path("flute.wav", base_dir, server=server)
+    pytest.data_path_flute_nonUnitaryCalib_in_container = get_test_file_path(
+        "flute_nonUnitaryCalib.wav", base_dir, server=server
     )
-    pytest.data_path_flute_nonUnitaryCalib_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "flute_nonUnitaryCalib.wav"), server=server
-    )
-    pytest.data_path_flute_nonUnitaryCalib_as_txt_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "flute_nonUnitaryCalib_as_text_2024R2_20241125.txt"),
+    pytest.data_path_flute_nonUnitaryCalib_as_txt_in_container = get_test_file_path(
+        "flute_nonUnitaryCalib_as_text_2024R2_20241125.txt",
+        base_dir,
         server=server,
     )
-    pytest.data_path_sharp_noise_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "sharp_noise.wav"), server=server
+    pytest.data_path_sharp_noise_in_container = get_test_file_path(
+        "sharp_noise.wav", base_dir, server=server
     )
-    pytest.data_path_sharper_noise_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "sharper_noise.wav"), server=server
+    pytest.data_path_sharper_noise_in_container = get_test_file_path(
+        "sharper_noise.wav", base_dir, server=server
     )
-    pytest.data_path_rough_noise_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "rough_noise.wav"), server=server
+    pytest.data_path_rough_noise_in_container = get_test_file_path(
+        "rough_noise.wav", base_dir, server=server
     )
-    pytest.data_path_rough_tone_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "rough_tone.wav"), server=server
+    pytest.data_path_rough_tone_in_container = get_test_file_path(
+        "rough_tone.wav", base_dir, server=server
     )
-    pytest.data_path_fluctuating_noise_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "fluctuating_noise.wav"), server=server
+    pytest.data_path_fluctuating_noise_in_container = get_test_file_path(
+        "fluctuating_noise.wav", base_dir, server=server
     )
-    pytest.data_path_white_noise_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "white_noise.wav"), server=server
+    pytest.data_path_white_noise_in_container = get_test_file_path(
+        "white_noise.wav", base_dir, server=server
     )
-    pytest.data_path_aircraft_nonUnitaryCalib_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "Aircraft-App2_nonUnitaryCalib.wav"), server=server
+    pytest.data_path_aircraft_nonUnitaryCalib_in_container = get_test_file_path(
+        "Aircraft-App2_nonUnitaryCalib.wav", base_dir, server=server
     )
-    pytest.data_path_Acceleration_stereo_nonUnitaryCalib = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "Acceleration_stereo_nonUnitaryCalib.wav"),
+    pytest.data_path_Acceleration_stereo_nonUnitaryCalib = get_test_file_path(
+        "Acceleration_stereo_nonUnitaryCalib.wav",
+        base_dir,
         server=server,
     )
-    pytest.data_path_accel_with_rpm_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "accel_with_rpm.wav"), server=server
+    pytest.data_path_accel_with_rpm_in_container = get_test_file_path(
+        "accel_with_rpm.wav", base_dir, server=server
     )
-    pytest.data_path_Acceleration_with_Tacho_nonUnitaryCalib = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "Acceleration_with_Tacho_nonUnitaryCalib.wav"),
+    pytest.data_path_Acceleration_with_Tacho_nonUnitaryCalib = get_test_file_path(
+        "Acceleration_with_Tacho_nonUnitaryCalib.wav",
+        base_dir,
         server=server,
     )
 
     # RPM profiles
-    pytest.data_path_rpm_profile_as_wav_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "RPM_profile_2024R2_20241126.wav"), server=server
+    pytest.data_path_rpm_profile_as_wav_in_container = get_test_file_path(
+        "RPM_profile_2024R2_20241126.wav", base_dir, server=server
     )
-    pytest.data_path_rpm_profile_as_txt_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "RPM_profile_2024R2_20241126.txt"), server=server
+    pytest.data_path_rpm_profile_as_txt_in_container = get_test_file_path(
+        "RPM_profile_2024R2_20241126.txt", base_dir, server=server
     )
 
     # Sound power level projects
-    pytest.data_path_swl_project_file_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "SoundPowerLevelProject_hemisphere_2025R1_20243008.spw"),
+    pytest.data_path_swl_project_file_in_container = get_test_file_path(
+        "SoundPowerLevelProject_hemisphere_2025R1_20243008.spw",
+        base_dir,
         server=server,
     )
-    pytest.data_path_swl_project_file_with_calibration_in_container = upload_file_in_tmp_folder(
-        os.path.join(
-            base_dir,
-            "SoundPowerLevelProject_hemisphere_signalsWithCalibration_2025R1_20240919.spw",
-        ),
+    pytest.data_path_swl_project_file_with_calibration_in_container = get_test_file_path(
+        "SoundPowerLevelProject_hemisphere_signalsWithCalibration_2025R1_20240919.spw",
+        base_dir,
         server=server,
     )
 
     # Sound composer files (including spectrum, harmonics, etc. data files)
-    pytest.data_path_sound_composer_spectrum_source_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "AnsysSound_Spectrum_v3_-_nominal_-_dBSPLperHz_2024R2_20241121.txt"),
+    pytest.data_path_sound_composer_spectrum_source_in_container = get_test_file_path(
+        "AnsysSound_Spectrum_v3_-_nominal_-_dBSPLperHz_2024R2_20241121.txt",
+        base_dir,
         server=server,
     )
-    pytest.data_path_sound_composer_harmonics_source_2p_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "AnsysSound_Orders_MultipleParameters dBSPL_2024R2_20241205.txt"),
+    pytest.data_path_sound_composer_harmonics_source_2p_in_container = get_test_file_path(
+        "AnsysSound_Orders_MultipleParameters dBSPL_2024R2_20241205.txt",
+        base_dir,
         server=server,
     )
     pytest.data_path_sound_composer_harmonics_source_2p_many_values_in_container = (
-        upload_file_in_tmp_folder(
-            os.path.join(
-                base_dir,
-                "AnsysSound_Orders_MultipleParameters dBSPL_many_values_2024R2_20241205.txt",
-            ),
+        get_test_file_path(
+            "AnsysSound_Orders_MultipleParameters dBSPL_many_values_2024R2_20241205.txt",
+            base_dir,
             server=server,
         )
     )
-    pytest.data_path_sound_composer_harmonics_source_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "AnsysSound_Orders dBSPL v1_2024R2_20241203.txt"), server=server
+    pytest.data_path_sound_composer_harmonics_source_in_container = get_test_file_path(
+        "AnsysSound_Orders dBSPL v1_2024R2_20241203.txt", base_dir, server=server
     )
     pytest.data_path_sound_composer_harmonics_source_10rpm_40orders_in_container = (
-        upload_file_in_tmp_folder(
-            os.path.join(
-                base_dir, "AnsysSound_Orders dBSPL v1_10_rpm_values_40_orders_2024R2_20241203.txt"
-            ),
+        get_test_file_path(
+            "AnsysSound_Orders dBSPL v1_10_rpm_values_40_orders_2024R2_20241203.txt",
+            base_dir,
             server=server,
         )
     )
     pytest.data_path_sound_composer_harmonics_source_2p_inverted_controls_in_container = (
-        upload_file_in_tmp_folder(
-            os.path.join(
-                base_dir,
-                "AnsysSound_Orders_MultipleParameters dBSPL - InvertedContols_2024R2_20241205.txt",
-            ),
+        get_test_file_path(
+            "AnsysSound_Orders_MultipleParameters dBSPL - InvertedContols_2024R2_20241205.txt",
+            base_dir,
             server=server,
         )
     )
     pytest.data_path_sound_composer_harmonics_source_2p_from_accel_in_container = (
-        upload_file_in_tmp_folder(
-            os.path.join(
-                base_dir,
-                "AnsysSound_Orders_MultipleParameters_FromAccelWithTacho_2024R2_20241205.txt",
-            ),
+        get_test_file_path(
+            "AnsysSound_Orders_MultipleParameters_FromAccelWithTacho_2024R2_20241205.txt",
+            base_dir,
             server=server,
         )
     )
-    pytest.data_path_sound_composer_harmonics_source_Pa_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "AnsysSound_Orders Pa v1_2024R2_20241203.txt"), server=server
+    pytest.data_path_sound_composer_harmonics_source_Pa_in_container = get_test_file_path(
+        "AnsysSound_Orders Pa v1_2024R2_20241203.txt", base_dir, server=server
     )
-    pytest.data_path_sound_composer_harmonics_source_wrong_type_in_container = (
-        upload_file_in_tmp_folder(
-            os.path.join(base_dir, "AnsysSound_Orders V2_2024R2_20241203.txt"), server=server
-        )
+    pytest.data_path_sound_composer_harmonics_source_wrong_type_in_container = get_test_file_path(
+        "AnsysSound_Orders V2_2024R2_20241203.txt", base_dir, server=server
     )
-    pytest.data_path_sound_composer_harmonics_source_xml_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "VRX_Waterfall_2024R2_20241203.xml"), server=server
+    pytest.data_path_sound_composer_harmonics_source_xml_in_container = get_test_file_path(
+        "VRX_Waterfall_2024R2_20241203.xml", base_dir, server=server
     )
-    pytest.data_path_sound_composer_bbn_source_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "AnsysSound_BBN dBSPL OCTAVE Constants.txt"), server=server
+    pytest.data_path_sound_composer_bbn_source_in_container = get_test_file_path(
+        "AnsysSound_BBN dBSPL OCTAVE Constants.txt", base_dir, server=server
     )
-    pytest.data_path_sound_composer_bbn_source_40_values_in_container = upload_file_in_tmp_folder(
-        os.path.join(
-            base_dir, "AnsysSound_BBN dBSPLperHz NARROWBAND v2_40values_2024R2_20241128.txt"
-        ),
+    pytest.data_path_sound_composer_bbn_source_40_values_in_container = get_test_file_path(
+        "AnsysSound_BBN dBSPLperHz NARROWBAND v2_40values_2024R2_20241128.txt",
+        base_dir,
         server=server,
     )
-    pytest.data_path_sound_composer_bbn_source_2p_in_container = upload_file_in_tmp_folder(
-        os.path.join(
-            base_dir, "AnsysSound_BBN_MultipleParameters Pa2PerHz Narrowband v2_2024R2_20240418.txt"
-        ),
+    pytest.data_path_sound_composer_bbn_source_2p_in_container = get_test_file_path(
+        "AnsysSound_BBN_MultipleParameters Pa2PerHz Narrowband v2_2024R2_20240418.txt",
+        base_dir,
         server=server,
     )
-    pytest.data_path_sound_composer_bbn_source_2p_octave_in_container = upload_file_in_tmp_folder(
-        os.path.join(
-            base_dir, "AnsysSound_BBN_MultipleParameters dBSPL Octave v2_2024R2_20240418.txt"
-        ),
+    pytest.data_path_sound_composer_bbn_source_2p_octave_in_container = get_test_file_path(
+        "AnsysSound_BBN_MultipleParameters dBSPL Octave v2_2024R2_20240418.txt",
+        base_dir,
         server=server,
     )
-    pytest.data_path_sound_composer_project_in_container = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "20250130_SoundComposerProjectForDpfSoundTesting_valid.scn"),
+    pytest.data_path_sound_composer_project_in_container = get_test_file_path(
+        "20250130_SoundComposerProjectForDpfSoundTesting_valid.scn",
+        base_dir,
         server=server,
     )
 
     # FRF files
-    pytest.data_path_filter_frf = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "AnsysSound_FRF_2024R2_20241206.txt"), server=server
+    pytest.data_path_filter_frf = get_test_file_path(
+        "AnsysSound_FRF_2024R2_20241206.txt", base_dir, server=server
     )
-    pytest.data_path_filter_frf_wrong_header = upload_file_in_tmp_folder(
-        os.path.join(base_dir, "AnsysSound_FRF_bad_2024R2_20241206.txt"), server=server
+    pytest.data_path_filter_frf_wrong_header = get_test_file_path(
+        "AnsysSound_FRF_bad_2024R2_20241206.txt", base_dir, server=server
     )
 
     # PSD file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def pytest_configure():
     # Use the conftest.py file's directory to set the base directory for the test data files.
     base_dir = os.path.join(os.path.dirname(__file__), "data")
 
-    def get_test_file_path(filename, base_dir, server):
+    def get_test_file_path(filename, base_dir, server) -> str:
         # Set the local path to the test file.
         local_path = os.path.join(base_dir, filename)
 


### PR DESCRIPTION
When using a local server, an `InProcess` server is now used by default (as opposed to a `gRPC` server previously).
An additional argument was added to still allow using a local `gRPC` server if needed.

Also, example 001 was modified as the local server test did not work as expected