### PR TITLE
fix: update tests following changes in DPF sound STFT

### DIFF
--- a/doc/changelog.d/290.fixed.md
+++ b/doc/changelog.d/290.fixed.md
@@ -1,0 +1,1 @@
+fix: update tests following changes in DPF sound STFT

--- a/tests/tests_spectrogram_processing/test_spectrogram_processing_stft.py
+++ b/tests/tests_spectrogram_processing/test_spectrogram_processing_stft.py
@@ -73,11 +73,11 @@ def test_stft_get_output():
     stft.process()
     fc_out = stft.get_output()
 
-    assert len(fc_out) == 310
+    assert len(fc_out) == 308
     assert len(fc_out[100].data) == stft.fft_size
-    assert fc_out[100].data[0] == -0.11434437334537506
-    assert fc_out[200].data[0] == -0.09117653965950012
-    assert fc_out[300].data[0] == -0.019828863441944122
+    assert fc_out[98].data[0] == -0.11434437334537506
+    assert fc_out[198].data[0] == -0.09117653965950012
+    assert fc_out[298].data[0] == -0.019828863441944122
 
 
 def test_stft_get_output_as_np_array():
@@ -89,12 +89,12 @@ def test_stft_get_output_as_np_array():
     stft.process()
     arr = stft.get_output_as_nparray()
 
-    assert np.shape(arr) == (stft.fft_size, 155)
+    assert np.shape(arr) == (stft.fft_size, 154)
 
     assert type(arr[100, 0]) == np.complex128
-    assert arr[100, 50] == (-1.0736324787139893 - 1.4027032852172852j)
-    assert arr[200, 50] == (0.511505126953125 + 0.3143689036369324j)
-    assert arr[300, 50] == (-0.03049434721469879 - 0.49174121022224426j)
+    assert arr[100, 49] == (-1.0736324787139893 - 1.4027032852172852j)
+    assert arr[200, 49] == (0.511505126953125 + 0.3143689036369324j)
+    assert arr[300, 49] == (-0.03049434721469879 - 0.49174121022224426j)
 
 
 def test_stft_set_get_signal():

--- a/tests/tests_xtract/test_xtract.py
+++ b/tests/tests_xtract/test_xtract.py
@@ -286,14 +286,14 @@ def test_xtract_get_output():
     noise, tonal, transient, remainder = xtract.get_output()
 
     # Check numerical apps.
-    assert np.min(noise.data) == pytest.approx(-0.2635681)
-    assert np.max(noise.data) == pytest.approx(0.30395156)
+    assert np.min(noise.data) == pytest.approx(-0.2724415361881256)
+    assert np.max(noise.data) == pytest.approx(0.30289316177368164)
 
-    assert np.min(tonal.data) == pytest.approx(-0.67513376)
-    assert np.max(tonal.data) == pytest.approx(0.79357791)
+    assert np.min(tonal.data) == pytest.approx(-0.6827592849731445)
+    assert np.max(tonal.data) == pytest.approx(0.8007676005363464)
 
-    assert np.min(transient.data) == pytest.approx(-0.20801553)
-    assert np.max(transient.data) == pytest.approx(0.21244156)
+    assert np.min(transient.data) == pytest.approx(-0.20742443203926086)
+    assert np.max(transient.data) == pytest.approx(0.2130335420370102)
 
     assert np.min(remainder.data) == pytest.approx(-7.95791721e-07)
     assert np.max(remainder.data) == pytest.approx(7.01886734e-07)
@@ -385,24 +385,24 @@ def test_xtract_get_output_fc():
     assert len(fc_remainder) == 2
 
     # Check numerical apps.
-    assert np.min(fc_noise[0].data) == pytest.approx(-0.2635681)
-    assert np.min(fc_tonal[0].data) == pytest.approx(-0.67513376)
-    assert np.min(fc_transient[0].data) == pytest.approx(-0.20801553)
+    assert np.min(fc_noise[0].data) == pytest.approx(-0.2724415361881256)
+    assert np.min(fc_tonal[0].data) == pytest.approx(-0.6827592849731445)
+    assert np.min(fc_transient[0].data) == pytest.approx(-0.20742443203926086)
     assert np.min(fc_remainder[0].data) == pytest.approx(-7.95791721e-07)
 
-    assert np.min(fc_noise[1].data) == pytest.approx(-0.2635681)
-    assert np.min(fc_tonal[1].data) == pytest.approx(-0.67513376)
-    assert np.min(fc_transient[1].data) == pytest.approx(-0.20801553)
+    assert np.min(fc_noise[1].data) == pytest.approx(-0.2724415361881256)
+    assert np.min(fc_tonal[1].data) == pytest.approx(-0.6827592849731445)
+    assert np.min(fc_transient[1].data) == pytest.approx(-0.20742443203926086)
     assert np.min(fc_remainder[1].data) == pytest.approx(-7.95791721e-07)
 
-    assert np.max(fc_noise[0].data) == pytest.approx(0.30395156)
-    assert np.max(fc_tonal[0].data) == pytest.approx(0.79357791)
-    assert np.max(fc_transient[0].data) == pytest.approx(0.21244156)
+    assert np.max(fc_noise[0].data) == pytest.approx(0.30289316177368164)
+    assert np.max(fc_tonal[0].data) == pytest.approx(0.8007676005363464)
+    assert np.max(fc_transient[0].data) == pytest.approx(0.2130335420370102)
     assert np.max(fc_remainder[0].data) == pytest.approx(7.01886734e-07)
 
-    assert np.max(fc_noise[1].data) == pytest.approx(0.30395156)
-    assert np.max(fc_tonal[1].data) == pytest.approx(0.79357791)
-    assert np.max(fc_transient[1].data) == pytest.approx(0.21244156)
+    assert np.max(fc_noise[1].data) == pytest.approx(0.30289316177368164)
+    assert np.max(fc_tonal[1].data) == pytest.approx(0.8007676005363464)
+    assert np.max(fc_transient[1].data) == pytest.approx(0.2130335420370102)
     assert np.max(fc_remainder[1].data) == pytest.approx(7.01886734e-07)
 
 
@@ -449,14 +449,14 @@ def test_xtract_get_output_as_nparray():
     assert type(np_remainder) == np.ndarray
 
     # Check numerical apps.
-    assert np.min(np_noise) == pytest.approx(-0.2635681)
-    assert np.max(np_noise) == pytest.approx(0.30395156)
+    assert np.min(np_noise) == pytest.approx(-0.2724415361881256)
+    assert np.max(np_noise) == pytest.approx(0.30289316177368164)
 
-    assert np.min(np_tonal) == pytest.approx(-0.67513376)
-    assert np.max(np_tonal) == pytest.approx(0.79357791)
+    assert np.min(np_tonal) == pytest.approx(-0.6827592849731445)
+    assert np.max(np_tonal) == pytest.approx(0.8007676005363464)
 
-    assert np.min(np_transient) == pytest.approx(-0.20801553)
-    assert np.max(np_transient) == pytest.approx(0.21244156)
+    assert np.min(np_transient) == pytest.approx(-0.20742443203926086)
+    assert np.max(np_transient) == pytest.approx(0.2130335420370102)
 
     assert np.min(np_remainder) == pytest.approx(-7.95791721e-07)
     assert np.max(np_remainder) == pytest.approx(7.01886734e-07)
@@ -524,24 +524,24 @@ def test_xtract_get_output_fc_as_nparray():
     assert np_fc_remainder[1] is not None
 
     # Check numerical apps.
-    assert np.min(np_fc_noise[0][:]) == pytest.approx(-0.2635681)
-    assert np.min(np_fc_tonal[0][:]) == pytest.approx(-0.6751337647438049)
-    assert np.min(np_fc_transient[0][:]) == pytest.approx(-0.20801553)
+    assert np.min(np_fc_noise[0][:]) == pytest.approx(-0.2724415361881256)
+    assert np.min(np_fc_tonal[0][:]) == pytest.approx(-0.6827592849731445)
+    assert np.min(np_fc_transient[0][:]) == pytest.approx(-0.20742443203926086)
     assert np.min(np_fc_remainder[0][:]) == pytest.approx(-7.957917205203557e-07)
 
-    assert np.min(np_fc_noise[1][:]) == pytest.approx(-0.2635681)
-    assert np.min(np_fc_tonal[1][:]) == pytest.approx(-0.67513376)
-    assert np.min(np_fc_transient[1][:]) == pytest.approx(-0.20801553)
+    assert np.min(np_fc_noise[1][:]) == pytest.approx(-0.2724415361881256)
+    assert np.min(np_fc_tonal[1][:]) == pytest.approx(-0.6827592849731445)
+    assert np.min(np_fc_transient[1][:]) == pytest.approx(-0.20742443203926086)
     assert np.min(np_fc_remainder[1][:]) == pytest.approx(-7.95791721e-07)
 
-    assert np.max(np_fc_noise[0][:]) == pytest.approx(0.30395156)
-    assert np.max(np_fc_tonal[0][:]) == pytest.approx(0.79357791)
-    assert np.max(np_fc_transient[0][:]) == pytest.approx(0.21244156)
+    assert np.max(np_fc_noise[0][:]) == pytest.approx(0.30289316177368164)
+    assert np.max(np_fc_tonal[0][:]) == pytest.approx(0.8007676005363464)
+    assert np.max(np_fc_transient[0][:]) == pytest.approx(0.2130335420370102)
     assert np.max(np_fc_remainder[0][:]) == pytest.approx(7.01886734e-07)
 
-    assert np.max(np_fc_noise[1][:]) == pytest.approx(0.30395156)
-    assert np.max(np_fc_tonal[1][:]) == pytest.approx(0.79357791)
-    assert np.max(np_fc_transient[1][:]) == pytest.approx(0.21244156)
+    assert np.max(np_fc_noise[1][:]) == pytest.approx(0.30289316177368164)
+    assert np.max(np_fc_tonal[1][:]) == pytest.approx(0.8007676005363464)
+    assert np.max(np_fc_transient[1][:]) == pytest.approx(0.2130335420370102)
     assert np.max(np_fc_remainder[1][:]) == pytest.approx(7.01886734e-07)
 
 

--- a/tests/tests_xtract/test_xtract_denoiser.py
+++ b/tests/tests_xtract/test_xtract_denoiser.py
@@ -95,7 +95,7 @@ def test_xtract_denoiser_process_except2():
     assert excinfo.value.args[0] == "Input parameters are not set."
 
 
-def test_xtract_process():
+def test_xtract_denoiser_process():
     wav_bird_plus_idle = LoadWav(pytest.data_path_flute_in_container)
     wav_bird_plus_idle.process()
 
@@ -125,8 +125,8 @@ def test_xtract_process():
     assert xtract_denoiser.get_output_as_nparray()[0][99] == pytest.approx(-3.329021806551297e-15)
 
     assert xtract_denoiser.get_output_as_nparray()[0].shape == (156048,)
-    assert np.min(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(-0.6995288133621216)
-    assert np.max(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(0.8091265559196472)
+    assert np.min(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(-0.7059202790260315)
+    assert np.max(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(0.8131743669509888)
 
     # Get the noise signal
     assert xtract_denoiser.get_output_as_nparray()[1][0] == pytest.approx(-4.048184330747483e-15)
@@ -294,8 +294,8 @@ def test_xtract_denoiser_get_output_as_nparray():
     assert xtract_denoiser.get_output_as_nparray()[0][99] == pytest.approx(-3.329021806551297e-15)
 
     assert xtract_denoiser.get_output_as_nparray()[0].shape == (156048,)
-    assert np.min(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(-0.6995288133621216)
-    assert np.max(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(0.8091265559196472)
+    assert np.min(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(-0.7059202790260315)
+    assert np.max(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(0.8131743669509888)
 
     # Get the noise signal
     assert xtract_denoiser.get_output_as_nparray()[1][0] == pytest.approx(-4.048184330747483e-15)

--- a/tests/tests_xtract/test_xtract_denoiser_parameters.py
+++ b/tests/tests_xtract/test_xtract_denoiser_parameters.py
@@ -78,7 +78,7 @@ def test_xtract_denoiser_parameters_generate_noise_psd_from_automatic_estimation
     noise = noise_psd.data
 
     s = np.sum(noise)
-    assert s == pytest.approx(0.0051941522299330245)
+    assert s == pytest.approx(0.00522007046561157)
 
 
 def test_xtract_denoiser_parameters_generate_noise_psd_from_noise_samples():


### PR DESCRIPTION
STFT computed in DPF Sound was corrected: an extra wrong frame is removed at the beginning of the STFT.
Tests are updated accordingly: STFT, Xtract