### PR TITLE
feat: old docker image housekeeping

### DIFF
--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -27,7 +27,7 @@ jobs:
     - name: "Perform docker image cleanup - except certain tags"
       uses: ansys/actions/hk-package-clean-except@9cef56e3b566d664473773f61079c401dddfabba # v10.0.6
       with:
-        package-name: 'sound'
+        package-name: 'ansys-sound'
         token: ${{ secrets.GITHUB_TOKEN }}
         tags-kept: '25.2, latest'
         allow-last-days: '150'

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -27,7 +27,7 @@ jobs:
     - name: "Perform docker image cleanup - except certain tags"
       uses: ansys/actions/hk-package-clean-except@9cef56e3b566d664473773f61079c401dddfabba # v10.0.6
       with:
-        package-name: 'ansys-sound-core'
+        package-name: 'sound'
         token: ${{ secrets.GITHUB_TOKEN }}
         tags-kept: '25.2, latest'
         allow-last-days: '150'

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -2,7 +2,7 @@ name: Docker image cleanup
 on:
   workflow_dispatch:
   schedule: # UTC at 0200 every Sunday
-    - cron: "11 16 * * *"
+    - cron: "11 19 * * *"
     # - cron: "0 2 * * 0"
 
 concurrency:

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -2,7 +2,7 @@ name: Docker image cleanup
 on:
   workflow_dispatch:
   schedule: # UTC at 0200 every Sunday
-    - cron: "20 11 * * *"
+    - cron: "25 9 * * *"
     # - cron: "0 2 * * 0"
 
 concurrency:

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -1,5 +1,8 @@
 name: Docker image cleanup
 on:
+  push:
+    branches:
+      - feat/old-docker-image-housekeeping
   schedule: # UTC at 0200 every Sunday
     - cron: "0 2 * * 0"
   workflow_dispatch:

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
     - name: "Perform docker image cleanup - except certain tags"
-      uses: ansys/actions/hk-package-clean-except@9cef56e3b566d664473773f61079c401dddfabba # v10.0.6
+      uses: ansys/actions/hk-package-clean-except@dce0e98a78079681554a90abde4ec81a7fa8e06a # v10.0.10
       with:
         package-name: 'ansys-sound'
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -1,0 +1,30 @@
+name: Docker image cleanup
+on:
+  workflow_dispatch:
+  schedule: # UTC at 0200 every Sunday
+    - cron: "0 2 * * 0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  cleanup:
+    name: Cleaning unnecessary docker images
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_DELETION_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+
+    - name: "Perform docker image cleanup - except certain tags"
+      uses: ansys/actions/hk-package-clean-except@9cef56e3b566d664473773f61079c401dddfabba # v10.0.6
+      with:
+        package-name: 'pyansys-sound'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tags-kept: '25.2, latest'
+        allow-last-days: '30'

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -1,8 +1,8 @@
 name: Docker image cleanup
 on:
-  workflow_dispatch:
   schedule: # UTC at 0200 every Sunday
     - cron: "0 2 * * 0"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -1,10 +1,8 @@
 name: Docker image cleanup
 on:
-  push:
   workflow_dispatch:
   schedule: # UTC at 0200 every Sunday
-    - cron: "25 9 * * *"
-    # - cron: "0 2 * * 0"
+    - cron: "0 2 * * 0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -1,5 +1,6 @@
 name: Docker image cleanup
 on:
+  push:
   workflow_dispatch:
   schedule: # UTC at 0200 every Sunday
     - cron: "25 9 * * *"

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -2,7 +2,7 @@ name: Docker image cleanup
 on:
   workflow_dispatch:
   schedule: # UTC at 0200 every Sunday
-    - cron: "11 19 * * *"
+    - cron: "20 11 * * *"
     # - cron: "0 2 * * 0"
 
 concurrency:

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -1,8 +1,8 @@
 name: Docker image cleanup
 on:
   workflow_dispatch:
-#   schedule: # UTC at 0200 every Sunday
-#     - cron: "0 2 * * 0"
+  schedule: # UTC at 0200 every Sunday
+    - cron: "0 2 * * 0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,4 +27,4 @@ jobs:
         package-name: 'pyansys-sound'
         token: ${{ secrets.GITHUB_TOKEN }}
         tags-kept: '25.2, latest'
-        allow-last-days: '30'
+        allow-last-days: '150'

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -1,8 +1,5 @@
 name: Docker image cleanup
 on:
-  push:
-    branches:
-      - feat/old-docker-image-housekeeping
   schedule: # UTC at 0200 every Sunday
     - cron: "0 2 * * 0"
   workflow_dispatch:

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -2,7 +2,8 @@ name: Docker image cleanup
 on:
   workflow_dispatch:
   schedule: # UTC at 0200 every Sunday
-    - cron: "0 2 * * 0"
+    - cron: "11 16 * * *"
+    # - cron: "0 2 * * 0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -30,4 +30,4 @@ jobs:
         package-name: 'ansys-sound'
         token: ${{ secrets.GITHUB_TOKEN }}
         tags-kept: '25.2, latest'
-        allow-last-days: '30'
+        allow-last-days: '15'

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -27,7 +27,7 @@ jobs:
     - name: "Perform docker image cleanup - except certain tags"
       uses: ansys/actions/hk-package-clean-except@9cef56e3b566d664473773f61079c401dddfabba # v10.0.6
       with:
-        package-name: 'pyansys-sound'
+        package-name: 'ansys-sound-core'
         token: ${{ secrets.GITHUB_TOKEN }}
         tags-kept: '25.2, latest'
         allow-last-days: '150'

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -1,4 +1,4 @@
-name: Docker image cleanup ***
+name: Docker image cleanup
 on:
   push:
     branches:
@@ -30,4 +30,4 @@ jobs:
         package-name: 'ansys-sound'
         token: ${{ secrets.GITHUB_TOKEN }}
         tags-kept: '25.2, latest'
-        allow-last-days: '150'
+        allow-last-days: '45'

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -1,8 +1,8 @@
 name: Docker image cleanup
 on:
   workflow_dispatch:
-  schedule: # UTC at 0200 every Sunday
-    - cron: "0 2 * * 0"
+#   schedule: # UTC at 0200 every Sunday
+#     - cron: "0 2 * * 0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -30,4 +30,4 @@ jobs:
         package-name: 'ansys-sound'
         token: ${{ secrets.GITHUB_TOKEN }}
         tags-kept: '25.2, latest'
-        allow-last-days: '45'
+        allow-last-days: '30'

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -1,4 +1,4 @@
-name: Docker image cleanup
+name: Docker image cleanup ***
 on:
   push:
     branches:

--- a/doc/changelog.d/296.added.md
+++ b/doc/changelog.d/296.added.md
@@ -1,0 +1,1 @@
+feat: old docker image housekeeping

--- a/doc/changelog.d/296.added.md
+++ b/doc/changelog.d/296.added.md
@@ -1,1 +1,0 @@
-feat: old docker image housekeeping

--- a/doc/changelog.d/296.maintenance.md
+++ b/doc/changelog.d/296.maintenance.md
@@ -1,0 +1,1 @@
+Feat: old docker image housekeeping


### PR DESCRIPTION
Added a new workflow, run manually or scheduled every Sunday at 2am UTC, that cleans up docker images older than 15 days.
Exceptions are official releases (eg `25.2`) and `latest`
![image](https://github.com/user-attachments/assets/511dd76f-0270-4ef4-83b2-3bbea758f31b)
