### PR TITLE
test: checking the DPF server version in new features, and in unit tests related to bug fixed in 2026 R1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,9 @@
 
 import os
 
+from ansys.dpf import core
 from ansys.dpf.core import upload_file_in_tmp_folder
+from ansys.dpf.core.check_version import get_server_version, meets_version
 import pytest
 
 from ansys.sound.core.server_helpers import connect_to_or_start_server
@@ -213,3 +215,14 @@ def pytest_configure(config):
 
     ## The temporary folder is the folder in the server where the files are stored.
     pytest.temporary_folder = os.path.dirname(pytest.data_path_flute_in_container)
+
+
+#### Define macros for server version checks
+# 11.0 corresponds to Ansys 2026 R1
+SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 = meets_version(
+    get_server_version(core._global_server()), "11.0"
+)
+# 10.0 corresponds to Ansys 2025 R2
+SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 = meets_version(
+    get_server_version(core._global_server()), "10.0"
+)

--- a/tests/tests_spectrogram_processing/test_spectrogram_processing_stft.py
+++ b/tests/tests_spectrogram_processing/test_spectrogram_processing_stft.py
@@ -29,6 +29,7 @@ import pytest
 from ansys.sound.core._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
 from ansys.sound.core.signal_utilities import LoadWav
 from ansys.sound.core.spectrogram_processing import Stft
+import conftest
 
 
 def test_stft_instantiation():
@@ -73,11 +74,18 @@ def test_stft_get_output():
     stft.process()
     fc_out = stft.get_output()
 
-    assert len(fc_out) == 308
-    assert len(fc_out[100].data) == stft.fft_size
-    assert fc_out[98].data[0] == -0.11434437334537506
-    assert fc_out[198].data[0] == -0.09117653965950012
-    assert fc_out[298].data[0] == -0.019828863441944122
+    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
+        # bug fix in DPF Sound 2026 R1 ID#1247009
+        assert len(fc_out) == 308
+        assert len(fc_out[100].data) == stft.fft_size
+        assert fc_out[98].data[0] == -0.11434437334537506
+        assert fc_out[198].data[0] == -0.09117653965950012
+        assert fc_out[298].data[0] == -0.019828863441944122
+    else:  # DPF Sound <= 2025 R2
+        assert len(fc_out) == 310
+        assert fc_out[100].data[0] == -0.11434437334537506
+        assert fc_out[200].data[0] == -0.09117653965950012
+        assert fc_out[300].data[0] == -0.019828863441944122
 
 
 def test_stft_get_output_as_np_array():
@@ -89,12 +97,19 @@ def test_stft_get_output_as_np_array():
     stft.process()
     arr = stft.get_output_as_nparray()
 
-    assert np.shape(arr) == (stft.fft_size, 154)
-
-    assert type(arr[100, 0]) == np.complex128
-    assert arr[100, 49] == (-1.0736324787139893 - 1.4027032852172852j)
-    assert arr[200, 49] == (0.511505126953125 + 0.3143689036369324j)
-    assert arr[300, 49] == (-0.03049434721469879 - 0.49174121022224426j)
+    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
+        # bug fix in DPF Sound 2026 R1 ID#1247009
+        assert np.shape(arr) == (stft.fft_size, 154)
+        assert type(arr[100, 0]) == np.complex128
+        assert arr[100, 49] == (-1.0736324787139893 - 1.4027032852172852j)
+        assert arr[200, 49] == (0.511505126953125 + 0.3143689036369324j)
+        assert arr[300, 49] == (-0.03049434721469879 - 0.49174121022224426j)
+    else:  # DPF Sound <= 2025 R2
+        assert np.shape(arr) == (stft.fft_size, 155)
+        assert type(arr[100, 0]) == np.complex128
+        assert arr[100, 50] == (-1.0736324787139893 - 1.4027032852172852j)
+        assert arr[200, 50] == (0.511505126953125 + 0.3143689036369324j)
+        assert arr[300, 50] == (-0.03049434721469879 - 0.49174121022224426j)
 
 
 def test_stft_set_get_signal():

--- a/tests/tests_xtract/test_xtract.py
+++ b/tests/tests_xtract/test_xtract.py
@@ -32,6 +32,7 @@ from ansys.sound.core.xtract.xtract import Xtract
 from ansys.sound.core.xtract.xtract_denoiser_parameters import XtractDenoiserParameters
 from ansys.sound.core.xtract.xtract_tonal_parameters import XtractTonalParameters
 from ansys.sound.core.xtract.xtract_transient_parameters import XtractTransientParameters
+import conftest
 
 
 def test_xtract_instantiation():
@@ -285,18 +286,33 @@ def test_xtract_get_output():
     ## Collecting outputs as Field
     noise, tonal, transient, remainder = xtract.get_output()
 
-    # Check numerical apps.
-    assert np.min(noise.data) == pytest.approx(-0.2724415361881256)
-    assert np.max(noise.data) == pytest.approx(0.30289316177368164)
+    # Check numerical values
+    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
+        # bug fix in DPF Sound 2026 R1 ID#1247009
+        assert np.min(noise.data) == pytest.approx(-0.2724415361881256)
+        assert np.max(noise.data) == pytest.approx(0.30289316177368164)
 
-    assert np.min(tonal.data) == pytest.approx(-0.6827592849731445)
-    assert np.max(tonal.data) == pytest.approx(0.8007676005363464)
+        assert np.min(tonal.data) == pytest.approx(-0.6827592849731445)
+        assert np.max(tonal.data) == pytest.approx(0.8007676005363464)
 
-    assert np.min(transient.data) == pytest.approx(-0.20742443203926086)
-    assert np.max(transient.data) == pytest.approx(0.2130335420370102)
+        assert np.min(transient.data) == pytest.approx(-0.20742443203926086)
+        assert np.max(transient.data) == pytest.approx(0.2130335420370102)
 
-    assert np.min(remainder.data) == pytest.approx(-7.95791721e-07)
-    assert np.max(remainder.data) == pytest.approx(7.01886734e-07)
+        assert np.min(remainder.data) == pytest.approx(-7.95791721e-07)
+        assert np.max(remainder.data) == pytest.approx(7.01886734e-07)
+
+    else:  # DPF Sound <= 2025 R2
+        assert np.min(noise.data) == pytest.approx(-0.2635681)
+        assert np.max(noise.data) == pytest.approx(0.30395156)
+
+        assert np.min(tonal.data) == pytest.approx(-0.67513376)
+        assert np.max(tonal.data) == pytest.approx(0.79357791)
+
+        assert np.min(transient.data) == pytest.approx(-0.20801553)
+        assert np.max(transient.data) == pytest.approx(0.21244156)
+
+        assert np.min(remainder.data) == pytest.approx(-7.95791721e-07)
+        assert np.max(remainder.data) == pytest.approx(7.01886734e-07)
 
 
 def test_xtract_get_output_noprocess():
@@ -384,26 +400,48 @@ def test_xtract_get_output_fc():
     assert len(fc_transient) == 2
     assert len(fc_remainder) == 2
 
-    # Check numerical apps.
-    assert np.min(fc_noise[0].data) == pytest.approx(-0.2724415361881256)
-    assert np.min(fc_tonal[0].data) == pytest.approx(-0.6827592849731445)
-    assert np.min(fc_transient[0].data) == pytest.approx(-0.20742443203926086)
-    assert np.min(fc_remainder[0].data) == pytest.approx(-7.95791721e-07)
+    # Check numerical values
+    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
+        # bug fix in DPF Sound 2026 R1 ID#1247009
+        assert np.min(fc_noise[0].data) == pytest.approx(-0.2724415361881256)
+        assert np.min(fc_tonal[0].data) == pytest.approx(-0.6827592849731445)
+        assert np.min(fc_transient[0].data) == pytest.approx(-0.20742443203926086)
+        assert np.min(fc_remainder[0].data) == pytest.approx(-7.95791721e-07)
 
-    assert np.min(fc_noise[1].data) == pytest.approx(-0.2724415361881256)
-    assert np.min(fc_tonal[1].data) == pytest.approx(-0.6827592849731445)
-    assert np.min(fc_transient[1].data) == pytest.approx(-0.20742443203926086)
-    assert np.min(fc_remainder[1].data) == pytest.approx(-7.95791721e-07)
+        assert np.min(fc_noise[1].data) == pytest.approx(-0.2724415361881256)
+        assert np.min(fc_tonal[1].data) == pytest.approx(-0.6827592849731445)
+        assert np.min(fc_transient[1].data) == pytest.approx(-0.20742443203926086)
+        assert np.min(fc_remainder[1].data) == pytest.approx(-7.95791721e-07)
 
-    assert np.max(fc_noise[0].data) == pytest.approx(0.30289316177368164)
-    assert np.max(fc_tonal[0].data) == pytest.approx(0.8007676005363464)
-    assert np.max(fc_transient[0].data) == pytest.approx(0.2130335420370102)
-    assert np.max(fc_remainder[0].data) == pytest.approx(7.01886734e-07)
+        assert np.max(fc_noise[0].data) == pytest.approx(0.30289316177368164)
+        assert np.max(fc_tonal[0].data) == pytest.approx(0.8007676005363464)
+        assert np.max(fc_transient[0].data) == pytest.approx(0.2130335420370102)
+        assert np.max(fc_remainder[0].data) == pytest.approx(7.01886734e-07)
 
-    assert np.max(fc_noise[1].data) == pytest.approx(0.30289316177368164)
-    assert np.max(fc_tonal[1].data) == pytest.approx(0.8007676005363464)
-    assert np.max(fc_transient[1].data) == pytest.approx(0.2130335420370102)
-    assert np.max(fc_remainder[1].data) == pytest.approx(7.01886734e-07)
+        assert np.max(fc_noise[1].data) == pytest.approx(0.30289316177368164)
+        assert np.max(fc_tonal[1].data) == pytest.approx(0.8007676005363464)
+        assert np.max(fc_transient[1].data) == pytest.approx(0.2130335420370102)
+        assert np.max(fc_remainder[1].data) == pytest.approx(7.01886734e-07)
+    else:  # DPF Sound <= 2025 R2
+        assert np.min(fc_noise[0].data) == pytest.approx(-0.2635681)
+        assert np.min(fc_tonal[0].data) == pytest.approx(-0.67513376)
+        assert np.min(fc_transient[0].data) == pytest.approx(-0.20801553)
+        assert np.min(fc_remainder[0].data) == pytest.approx(-7.95791721e-07)
+
+        assert np.min(fc_noise[1].data) == pytest.approx(-0.2635681)
+        assert np.min(fc_tonal[1].data) == pytest.approx(-0.67513376)
+        assert np.min(fc_transient[1].data) == pytest.approx(-0.20801553)
+        assert np.min(fc_remainder[1].data) == pytest.approx(-7.95791721e-07)
+
+        assert np.max(fc_noise[0].data) == pytest.approx(0.30395156)
+        assert np.max(fc_tonal[0].data) == pytest.approx(0.79357791)
+        assert np.max(fc_transient[0].data) == pytest.approx(0.21244156)
+        assert np.max(fc_remainder[0].data) == pytest.approx(7.01886734e-07)
+
+        assert np.max(fc_noise[1].data) == pytest.approx(0.30395156)
+        assert np.max(fc_tonal[1].data) == pytest.approx(0.79357791)
+        assert np.max(fc_transient[1].data) == pytest.approx(0.21244156)
+        assert np.max(fc_remainder[1].data) == pytest.approx(7.01886734e-07)
 
 
 def test_xtract_get_output_as_nparray():
@@ -448,18 +486,33 @@ def test_xtract_get_output_as_nparray():
     assert type(np_transient) == np.ndarray
     assert type(np_remainder) == np.ndarray
 
-    # Check numerical apps.
-    assert np.min(np_noise) == pytest.approx(-0.2724415361881256)
-    assert np.max(np_noise) == pytest.approx(0.30289316177368164)
+    # Check numerical values
+    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
+        # bug fix in DPF Sound 2026 R1 ID#1247009
+        assert np.min(np_noise) == pytest.approx(-0.2724415361881256)
+        assert np.max(np_noise) == pytest.approx(0.30289316177368164)
 
-    assert np.min(np_tonal) == pytest.approx(-0.6827592849731445)
-    assert np.max(np_tonal) == pytest.approx(0.8007676005363464)
+        assert np.min(np_tonal) == pytest.approx(-0.6827592849731445)
+        assert np.max(np_tonal) == pytest.approx(0.8007676005363464)
 
-    assert np.min(np_transient) == pytest.approx(-0.20742443203926086)
-    assert np.max(np_transient) == pytest.approx(0.2130335420370102)
+        assert np.min(np_transient) == pytest.approx(-0.20742443203926086)
+        assert np.max(np_transient) == pytest.approx(0.2130335420370102)
 
-    assert np.min(np_remainder) == pytest.approx(-7.95791721e-07)
-    assert np.max(np_remainder) == pytest.approx(7.01886734e-07)
+        assert np.min(np_remainder) == pytest.approx(-7.95791721e-07)
+        assert np.max(np_remainder) == pytest.approx(7.01886734e-07)
+
+    else:  # DPF Sound <= 2025 R2
+        assert np.min(np_noise) == pytest.approx(-0.2635681)
+        assert np.max(np_noise) == pytest.approx(0.30395156)
+
+        assert np.min(np_tonal) == pytest.approx(-0.67513376)
+        assert np.max(np_tonal) == pytest.approx(0.79357791)
+
+        assert np.min(np_transient) == pytest.approx(-0.20801553)
+        assert np.max(np_transient) == pytest.approx(0.21244156)
+
+        assert np.min(np_remainder) == pytest.approx(-7.95791721e-07)
+        assert np.max(np_remainder) == pytest.approx(7.01886734e-07)
 
 
 def test_xtract_get_output_fc_as_nparray():

--- a/tests/tests_xtract/test_xtract_denoiser.py
+++ b/tests/tests_xtract/test_xtract_denoiser.py
@@ -30,6 +30,7 @@ from ansys.sound.core._pyansys_sound import PyAnsysSoundException, PyAnsysSoundW
 from ansys.sound.core.signal_utilities import LoadWav
 from ansys.sound.core.xtract.xtract_denoiser import XtractDenoiser
 from ansys.sound.core.xtract.xtract_denoiser_parameters import XtractDenoiserParameters
+import conftest
 
 
 def test_xtract_denoiser_instantiation():
@@ -125,8 +126,22 @@ def test_xtract_denoiser_process():
     assert xtract_denoiser.get_output_as_nparray()[0][99] == pytest.approx(-3.329021806551297e-15)
 
     assert xtract_denoiser.get_output_as_nparray()[0].shape == (156048,)
-    assert np.min(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(-0.7059202790260315)
-    assert np.max(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(0.8131743669509888)
+
+    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
+        # bug fix in DPF Sound 2026 R1 ID#1247009
+        assert np.min(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(
+            -0.7059202790260315
+        )
+        assert np.max(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(
+            0.8131743669509888
+        )
+    else:  # DPF Sound <= 2025 R2
+        assert np.min(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(
+            -0.6995288133621216
+        )
+        assert np.max(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(
+            0.8091265559196472
+        )
 
     # Get the noise signal
     assert xtract_denoiser.get_output_as_nparray()[1][0] == pytest.approx(-4.048184330747483e-15)
@@ -294,8 +309,23 @@ def test_xtract_denoiser_get_output_as_nparray():
     assert xtract_denoiser.get_output_as_nparray()[0][99] == pytest.approx(-3.329021806551297e-15)
 
     assert xtract_denoiser.get_output_as_nparray()[0].shape == (156048,)
-    assert np.min(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(-0.7059202790260315)
-    assert np.max(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(0.8131743669509888)
+
+    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
+        # bug fix in DPF Sound 2026 R1 ID#1247009
+        assert np.min(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(
+            -0.7059202790260315
+        )
+        assert np.max(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(
+            0.8131743669509888
+        )
+
+    else:  # DPF Sound <= 2025 R2
+        assert np.min(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(
+            -0.6995288133621216
+        )
+        assert np.max(xtract_denoiser.get_output_as_nparray()[0]) == pytest.approx(
+            0.8091265559196472
+        )
 
     # Get the noise signal
     assert xtract_denoiser.get_output_as_nparray()[1][0] == pytest.approx(-4.048184330747483e-15)

--- a/tests/tests_xtract/test_xtract_denoiser_parameters.py
+++ b/tests/tests_xtract/test_xtract_denoiser_parameters.py
@@ -27,6 +27,7 @@ import pytest
 from ansys.sound.core._pyansys_sound import PyAnsysSoundException
 from ansys.sound.core.signal_utilities import LoadWav
 from ansys.sound.core.xtract.xtract_denoiser_parameters import XtractDenoiserParameters
+import conftest
 
 
 def test_xtract_denoiser_parameters_instantiation():
@@ -78,7 +79,12 @@ def test_xtract_denoiser_parameters_generate_noise_psd_from_automatic_estimation
     noise = noise_psd.data
 
     s = np.sum(noise)
-    assert s == pytest.approx(0.00522007046561157)
+
+    if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
+        # bug fix in DPF Sound 2026 R1 ID#1247009
+        assert s == pytest.approx(0.00522007046561157)
+    else:  # DPF Sound <= 2025 R2
+        assert s == pytest.approx(0.0051941522299330245)
 
 
 def test_xtract_denoiser_parameters_generate_noise_psd_from_noise_samples():


### PR DESCRIPTION
Adding conditions on the version of DPF server in unit tests, as some bug fixes done in DPF Sound 2026 R1 changed the output values from 2025 R2.

Also adding some checks of the version of the DPF server for the features that appeared in DPF Sound 2026 R1, who depends on DPF server 11.0 (ie 26R1).