### PR TITLE
ci: run CI/CD tests on all past official releases, in addition to the latest package

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -250,7 +250,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Download DPF-Sound service container for released documentation"
+      - name: "Download DPF-Sound service container"
         run: docker pull ${{ env.ANSRV_DPF_SOUND_REPO }}:${{ env.DOCUMENTATION_DPF_SOUND_TAG }}
 
       - name: "Start DPF-Sound service and verify start"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -18,6 +18,7 @@ env:
   MAIN_PYTHON_VERSION: '3.12'
   PACKAGE_NAME: 'ansys-sound-core'
   DOCUMENTATION_CNAME: 'sound.docs.pyansys.com'
+  DOCUMENTATION_DPF_SOUND_VERSION: '25.2' # Version of DPF Sound to use for documentation
   ANSRV_DPF_SOUND_REPO: ghcr.io/ansys/ansys-sound # Docker repository for DPF Sound
   ANSRV_DPF_SOUND_PORT: 6780 # Port for DPF Sound Docker containers
   DPF_SOUND_CONT_NAME: ansys-sound-core
@@ -233,7 +234,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Download DPF-Sound service container"
+      - name: "Download DPF-Sound service container for released documentation"
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+        run: docker pull ${{ env.ANSRV_DPF_SOUND_REPO }}:${{ env.DOCUMENTATION_DPF_SOUND_VERSION }}
+      
+      - name: "Download DPF-Sound service container for development documentation"
+        if: github.event_name != 'push' || !contains(github.ref, 'refs/tags')
         run: docker pull ${{ env.ANSRV_DPF_SOUND_REPO }}:latest
 
       - name: "Start DPF-Sound service and verify start"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -111,6 +111,8 @@ jobs:
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 # =================================================================================================
 
+  # Retrieve test matrix from the environment variable, as env variables are not directly available
+  # at matrix definition (in job testing-windows below).
   retrieve-test-matrix:
     name: "Retrieve test matrix of DPF Sound Docker images"
     runs-on: ubuntu-latest
@@ -132,6 +134,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # This matrix contains tags of all DPF Sound Docker images to test against.
+        # (see env.TEST_DPF_SOUND_MATRIX)
         docker-image: ${{ fromJson(needs.retrieve-test-matrix.outputs.matrix) }}
 
     steps:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -18,8 +18,8 @@ env:
   MAIN_PYTHON_VERSION: '3.12'
   PACKAGE_NAME: 'ansys-sound-core'
   DOCUMENTATION_CNAME: 'sound.docs.pyansys.com'
-  ANSRV_DPF_SOUND_IMAGE_WINDOWS_TAG: ghcr.io/ansys/ansys-sound:latest
-  ANSRV_DPF_SOUND_PORT: 6780
+  ANSRV_DPF_SOUND_REPO: ghcr.io/ansys/ansys-sound # Docker repository for DPF Sound
+  ANSRV_DPF_SOUND_PORT: 6780 # Port for DPF Sound Docker containers
   DPF_SOUND_CONT_NAME: ansys-sound-core
 
 jobs:
@@ -116,6 +116,10 @@ jobs:
     env:
       PYVISTA_OFF_SCREEN: true
       MPLBACKEND: Agg  # non-interactive mode ("headless backend") for matplotlib: no GUI is used when plotting
+    strategy:
+      fail-fast: false
+      matrix:
+        docker-image: [25.2, latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -150,12 +154,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download DPF-Sound service container
-        run: docker pull $env:ANSRV_DPF_SOUND_IMAGE_WINDOWS_TAG
+        run: docker pull ${{ env.ANSRV_DPF_SOUND_REPO }}:${{ matrix.docker-image }}
 
       - name: "Start DPF-Sound service and verify start"
         run: |
           .\.venv\Scripts\Activate.ps1
-          docker run -d --name ${{ env.DPF_SOUND_CONT_NAME }} -e "ANSYS_DPF_ACCEPT_LA=Y" -e "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" -p ${{ env.ANSRV_DPF_SOUND_PORT }}:50052 --dns '8.8.8.8' ${{ env.ANSRV_DPF_SOUND_IMAGE_WINDOWS_TAG }}
+          docker run -d --name ${{ env.DPF_SOUND_CONT_NAME }} -e "ANSYS_DPF_ACCEPT_LA=Y" -e "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" -p ${{ env.ANSRV_DPF_SOUND_PORT }}:50052 --dns '8.8.8.8' ${{ env.ANSRV_DPF_SOUND_REPO }}:${{ matrix.docker-image }}
           python -c "from ansys.sound.core.server_helpers import validate_dpf_sound_connection; validate_dpf_sound_connection()"
 
       - name: "Testing"
@@ -166,7 +170,7 @@ jobs:
       - name: "Upload Coverage Results"
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-html
+          name: coverage-html-${{ matrix.docker-image }}
           path: .cov/html
           retention-days: 7
 
@@ -175,7 +179,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: .cov/xml
-
 
       - name: "Stop the DPF-Sound service"
         if: always()
@@ -231,12 +234,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Download DPF-Sound service container"
-        run: docker pull $env:ANSRV_DPF_SOUND_IMAGE_WINDOWS_TAG
+        run: docker pull ${{ env.ANSRV_DPF_SOUND_REPO }}:latest
 
       - name: "Start DPF-Sound service and verify start"
         run: |
           .\.venv\Scripts\Activate.ps1
-          docker run -d --name ${{ env.DPF_SOUND_CONT_NAME }} -e "ANSYS_DPF_ACCEPT_LA=Y" -e "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" -p ${{ env.ANSRV_DPF_SOUND_PORT }}:50052 --dns '8.8.8.8' ${{ env.ANSRV_DPF_SOUND_IMAGE_WINDOWS_TAG }}
+          docker run -d --name ${{ env.DPF_SOUND_CONT_NAME }} -e "ANSYS_DPF_ACCEPT_LA=Y" -e "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" -p ${{ env.ANSRV_DPF_SOUND_PORT }}:50052 --dns '8.8.8.8' ${{ env.ANSRV_DPF_SOUND_REPO }}:latest
           python -c "from ansys.sound.core.server_helpers import validate_dpf_sound_connection; validate_dpf_sound_connection()"
 
       - name: "Run Ansys documentation building action"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -18,7 +18,8 @@ env:
   MAIN_PYTHON_VERSION: '3.12'
   PACKAGE_NAME: 'ansys-sound-core'
   DOCUMENTATION_CNAME: 'sound.docs.pyansys.com'
-  DOCUMENTATION_DPF_SOUND_VERSION: '25.2' # Version of DPF Sound to use for documentation
+  DOCUMENTATION_DPF_SOUND_TAG: 'latest' # DPF Sound image tag for doc building
+  TEST_DPF_SOUND_MATRIX: '["25.2", "latest"]' # List of DPF Sound image tags for testing (quotes and double quotes are important!!)
   ANSRV_DPF_SOUND_REPO: ghcr.io/ansys/ansys-sound # Docker repository for DPF Sound
   ANSRV_DPF_SOUND_PORT: 6780 # Port for DPF Sound Docker containers
   DPF_SOUND_CONT_NAME: ansys-sound-core
@@ -110,9 +111,20 @@ jobs:
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 # =================================================================================================
 
+  retrieve-test-matrix:
+    name: "Retrieve test matrix of DPF Sound Docker images"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: echo "matrix=${TEST_DPF_SOUND_MATRIX}" >> $GITHUB_OUTPUT
+        env:
+          TEST_DPF_SOUND_MATRIX: ${{ env.TEST_DPF_SOUND_MATRIX }}
+
   testing-windows:
     name: "Testing and coverage (Windows)"
-    needs: [smoke-tests]
+    needs: [smoke-tests, retrieve-test-matrix]
     runs-on: [self-hosted, Windows, pyansys-sound]
     env:
       PYVISTA_OFF_SCREEN: true
@@ -120,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        docker-image: [25.2, latest]
+        docker-image: ${{ fromJson(needs.retrieve-test-matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -235,17 +247,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Download DPF-Sound service container for released documentation"
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-        run: docker pull ${{ env.ANSRV_DPF_SOUND_REPO }}:${{ env.DOCUMENTATION_DPF_SOUND_VERSION }}
-
-      - name: "Download DPF-Sound service container for development documentation"
-        if: github.event_name != 'push' || !contains(github.ref, 'refs/tags')
-        run: docker pull ${{ env.ANSRV_DPF_SOUND_REPO }}:latest
+        run: docker pull ${{ env.ANSRV_DPF_SOUND_REPO }}:${{ env.DOCUMENTATION_DPF_SOUND_TAG }}
 
       - name: "Start DPF-Sound service and verify start"
         run: |
           .\.venv\Scripts\Activate.ps1
-          docker run -d --name ${{ env.DPF_SOUND_CONT_NAME }} -e "ANSYS_DPF_ACCEPT_LA=Y" -e "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" -p ${{ env.ANSRV_DPF_SOUND_PORT }}:50052 --dns '8.8.8.8' ${{ env.ANSRV_DPF_SOUND_REPO }}:latest
+          docker run -d --name ${{ env.DPF_SOUND_CONT_NAME }} -e "ANSYS_DPF_ACCEPT_LA=Y" -e "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" -p ${{ env.ANSRV_DPF_SOUND_PORT }}:50052 --dns '8.8.8.8' ${{ env.ANSRV_DPF_SOUND_REPO }}:${{ env.DOCUMENTATION_DPF_SOUND_TAG }}
           python -c "from ansys.sound.core.server_helpers import validate_dpf_sound_connection; validate_dpf_sound_connection()"
 
       - name: "Run Ansys documentation building action"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -237,7 +237,7 @@ jobs:
       - name: "Download DPF-Sound service container for released documentation"
         if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
         run: docker pull ${{ env.ANSRV_DPF_SOUND_REPO }}:${{ env.DOCUMENTATION_DPF_SOUND_VERSION }}
-      
+
       - name: "Download DPF-Sound service container for development documentation"
         if: github.event_name != 'push' || !contains(github.ref, 'refs/tags')
         run: docker pull ${{ env.ANSRV_DPF_SOUND_REPO }}:latest

--- a/doc/changelog.d/316.miscellaneous.md
+++ b/doc/changelog.d/316.miscellaneous.md
@@ -1,0 +1,1 @@
+Ci: run ci/cd tests on all past official releases, in addition to the latest package

--- a/tests/tests_xtract/test_xtract.py
+++ b/tests/tests_xtract/test_xtract.py
@@ -575,26 +575,48 @@ def test_xtract_get_output_fc_as_nparray():
     assert np_fc_transient[1] is not None
     assert np_fc_remainder[1] is not None
 
-    # Check numerical apps.
-    assert np.min(np_fc_noise[0][:]) == pytest.approx(-0.2724415361881256)
-    assert np.min(np_fc_tonal[0][:]) == pytest.approx(-0.6827592849731445)
-    assert np.min(np_fc_transient[0][:]) == pytest.approx(-0.20742443203926086)
-    assert np.min(np_fc_remainder[0][:]) == pytest.approx(-7.957917205203557e-07)
+    # Check numerical values
+    if pytest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
+        # bug fix in DPF Sound 2026 R1 ID#1247009
+        assert np.min(np_fc_noise[0][:]) == pytest.approx(-0.2724415361881256)
+        assert np.min(np_fc_tonal[0][:]) == pytest.approx(-0.6827592849731445)
+        assert np.min(np_fc_transient[0][:]) == pytest.approx(-0.20742443203926086)
+        assert np.min(np_fc_remainder[0][:]) == pytest.approx(-7.957917205203557e-07)
 
-    assert np.min(np_fc_noise[1][:]) == pytest.approx(-0.2724415361881256)
-    assert np.min(np_fc_tonal[1][:]) == pytest.approx(-0.6827592849731445)
-    assert np.min(np_fc_transient[1][:]) == pytest.approx(-0.20742443203926086)
-    assert np.min(np_fc_remainder[1][:]) == pytest.approx(-7.95791721e-07)
+        assert np.min(np_fc_noise[1][:]) == pytest.approx(-0.2724415361881256)
+        assert np.min(np_fc_tonal[1][:]) == pytest.approx(-0.6827592849731445)
+        assert np.min(np_fc_transient[1][:]) == pytest.approx(-0.20742443203926086)
+        assert np.min(np_fc_remainder[1][:]) == pytest.approx(-7.95791721e-07)
 
-    assert np.max(np_fc_noise[0][:]) == pytest.approx(0.30289316177368164)
-    assert np.max(np_fc_tonal[0][:]) == pytest.approx(0.8007676005363464)
-    assert np.max(np_fc_transient[0][:]) == pytest.approx(0.2130335420370102)
-    assert np.max(np_fc_remainder[0][:]) == pytest.approx(7.01886734e-07)
+        assert np.max(np_fc_noise[0][:]) == pytest.approx(0.30289316177368164)
+        assert np.max(np_fc_tonal[0][:]) == pytest.approx(0.8007676005363464)
+        assert np.max(np_fc_transient[0][:]) == pytest.approx(0.2130335420370102)
+        assert np.max(np_fc_remainder[0][:]) == pytest.approx(7.01886734e-07)
 
-    assert np.max(np_fc_noise[1][:]) == pytest.approx(0.30289316177368164)
-    assert np.max(np_fc_tonal[1][:]) == pytest.approx(0.8007676005363464)
-    assert np.max(np_fc_transient[1][:]) == pytest.approx(0.2130335420370102)
-    assert np.max(np_fc_remainder[1][:]) == pytest.approx(7.01886734e-07)
+        assert np.max(np_fc_noise[1][:]) == pytest.approx(0.30289316177368164)
+        assert np.max(np_fc_tonal[1][:]) == pytest.approx(0.8007676005363464)
+        assert np.max(np_fc_transient[1][:]) == pytest.approx(0.2130335420370102)
+        assert np.max(np_fc_remainder[1][:]) == pytest.approx(7.01886734e-07)
+    else:  # DPF Sound <= 2025 R2
+        assert np.min(np_fc_noise[0].data) == pytest.approx(-0.2635681)
+        assert np.min(np_fc_tonal[0].data) == pytest.approx(-0.67513376)
+        assert np.min(np_fc_transient[0].data) == pytest.approx(-0.20801553)
+        assert np.min(np_fc_remainder[0].data) == pytest.approx(-7.95791721e-07)
+
+        assert np.min(np_fc_noise[1].data) == pytest.approx(-0.2635681)
+        assert np.min(np_fc_tonal[1].data) == pytest.approx(-0.67513376)
+        assert np.min(np_fc_transient[1].data) == pytest.approx(-0.20801553)
+        assert np.min(np_fc_remainder[1].data) == pytest.approx(-7.95791721e-07)
+
+        assert np.max(np_fc_noise[0].data) == pytest.approx(0.30395156)
+        assert np.max(np_fc_tonal[0].data) == pytest.approx(0.79357791)
+        assert np.max(np_fc_transient[0].data) == pytest.approx(0.21244156)
+        assert np.max(np_fc_remainder[0].data) == pytest.approx(7.01886734e-07)
+
+        assert np.max(np_fc_noise[1].data) == pytest.approx(0.30395156)
+        assert np.max(np_fc_tonal[1].data) == pytest.approx(0.79357791)
+        assert np.max(np_fc_transient[1].data) == pytest.approx(0.21244156)
+        assert np.max(np_fc_remainder[1].data) == pytest.approx(7.01886734e-07)
 
 
 def test_xtract_setters():


### PR DESCRIPTION
Starting with release 25.2, every CI/CD run will test against past official DPF Sound releases, in addition to the latest package.
This is managed in the `TEST_DPF_SOUND_MATRIX` environment variable defined at the start of `ci_cd.yml`
Additionally the (unique) image used for doc build is also stored in an environment variable `DOCUMENTATION_DPF_SOUND_TAG` and shall be updated for each release

Also fixed an xtract test that would not pass in 25.2 (omitted in the previous STFT bug fix PR)