### PR TITLE
ci: adding ``release to github`` in cicd

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -327,6 +327,14 @@ jobs:
           packages-dir: ${{ env.PACKAGE_NAME }}-artifacts
           skip-existing: false
 
+      - name: "Release to GitHub"
+        uses: ansys/actions/release-github@v10
+        with:
+          library-name: ${{ env.PACKAGE_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-artifact-attestation-notes: true
+          changelog-release-notes: true
+
   doc-deploy-dev:
     name: "Upload developers documentation"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -328,7 +328,7 @@ jobs:
           skip-existing: false
 
       - name: "Release to GitHub"
-        uses: ansys/actions/release-github@v10
+        uses: ansys/actions/release-github@8d3e4946f36c2a7d447b92e34b1022a5c9dc77a7 # v10.0.12
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/changelog.d/320.miscellaneous.md
+++ b/doc/changelog.d/320.miscellaneous.md
@@ -1,0 +1,1 @@
+Ci: adding ``release to guthub`` in cicd

--- a/doc/changelog.d/320.miscellaneous.md
+++ b/doc/changelog.d/320.miscellaneous.md
@@ -1,1 +1,1 @@
-Ci: adding ``release to guthub`` in cicd
+Ci: adding ``release to github`` in cicd


### PR DESCRIPTION
New release has not been deployed to GitHub because this job was missing to the CICD.
This should fix it.