### PR TITLE
ci: update the ``check-vulnerabilities`` action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -80,24 +80,8 @@ jobs:
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
 
-
-  check-vulnerabilities-dev:
-    name: "Check library vulnerabilities (development mode)"
-    if: github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Check library vulnerabilities with development mode"
-        uses: ansys/actions/check-vulnerabilities@main
-        with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
-          python-package-name: ${{ env.PACKAGE_NAME }}
-          dev-mode: true
-
-
-  check-vulnerabilities-main:
-    name: "Check library vulnerabilities (default mode - only on main)"
-    if: github.ref == 'refs/heads/main'
+  vulnerabilities:
+    name: "Check library vulnerabilities"
     runs-on: ubuntu-latest
     steps:
       - name: "Check library vulnerabilities with default mode"
@@ -106,6 +90,7 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           python-package-name: ${{ env.PACKAGE_NAME }}
+          dev-mode: ${{ github.ref != 'refs/heads/main' }}
 
 # =================================================================================================
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
@@ -339,7 +324,7 @@ jobs:
   doc-deploy-dev:
     name: "Upload developers documentation"
     runs-on: ubuntu-latest
-    needs: [check-vulnerabilities-main, package]
+    needs: [vulnerabilities, package]
     if: github.ref == 'refs/heads/main'
     steps:
       - name: "Deploy the latest documentation"

--- a/doc/changelog.d/323.miscellaneous.md
+++ b/doc/changelog.d/323.miscellaneous.md
@@ -1,0 +1,1 @@
+Ci: update the ``check-vulnerabilities`` action


### PR DESCRIPTION
Some changes have been made in the ``check-vulnerabilities`` action. You can now pass a ``dev-mode`` argument in order to have a unique job in your workflow file. You can have a look at the action documentation [here](https://actions.docs.ansys.com/version/stable/vulnerability-actions/index.html#examples).
This PR applies those latest changes