### PR TITLE
feat: 1/3-octave- and octave-band levels from PSD

### DIFF
--- a/doc/changelog.d/327.miscellaneous.md
+++ b/doc/changelog.d/327.miscellaneous.md
@@ -1,0 +1,1 @@
+Feat: 1/3-octave- and octave-band levels from PSD

--- a/doc/source/api/standard_levels.rst
+++ b/doc/source/api/standard_levels.rst
@@ -10,3 +10,5 @@ This module provides functions to calculate standard levels from time-domain sig
 
     OverallLevel
     LevelOverTime
+    OneThirdOctaveLevelsFromPSD
+    OctaveLevelsFromPSD

--- a/src/ansys/sound/core/psychoacoustics/tonality_ecma_418_2.py
+++ b/src/ansys/sound/core/psychoacoustics/tonality_ecma_418_2.py
@@ -47,7 +47,7 @@ class TonalityECMA418_2(PsychoacousticsParent):
         psychoacoustic tonality calculation. However, the standard does not include any real
         verification data and its 1st edition noticeably included errors and unclear computation
         details open to interpretation. The 3rd edition was largely improved in that regard, and
-        now allow producing consistent results throughout distinct implementations of the standard.
+        now allows producing consistent results throughout distinct implementations of the standard.
         As a consequence, this 3rd edition is strongly recommended in most cases, while the 1st
         edition should only be used when backward compatibility is required.
 
@@ -59,8 +59,8 @@ class TonalityECMA418_2(PsychoacousticsParent):
         :attr:`field_type`. This means that older code using this class needs be updated with
         values assigned to these two attributes. This can be done either when instantiating the
         class:``my_tonality = TonalityECMA418_2(my_signal, my_field_type, my_edition)``, or later,
-        by setting the attributes: ``my_tonality.field_type = my_field_type`` and
-        ``my_tonality.edition = my_edition``.
+        by setting the :attr:`field_type` and :attr:`edition` attributes:
+        ``my_tonality.field_type = my_field_type`` and ``my_tonality.edition = my_edition``.
     """
 
     def __init__(self, signal: Field = None, field_type: str = None, edition: str = None):

--- a/src/ansys/sound/core/standard_levels/__init__.py
+++ b/src/ansys/sound/core/standard_levels/__init__.py
@@ -27,10 +27,14 @@ Helper classes related to the computation of standard levels.
 
 from ._standard_levels_parent import StandardLevelsParent
 from .level_over_time import LevelOverTime
+from .octave_levels_from_psd import OctaveLevelsFromPSD
+from .one_third_octave_levels_from_psd import OneThirdOctaveLevelsFromPSD
 from .overall_level import OverallLevel
 
 __all__ = (
     "StandardLevelsParent",
     "OverallLevel",
     "LevelOverTime",
+    "OctaveLevelsFromPSD",
+    "OneThirdOctaveLevelsFromPSD",
 )

--- a/src/ansys/sound/core/standard_levels/level_over_time.py
+++ b/src/ansys/sound/core/standard_levels/level_over_time.py
@@ -67,12 +67,12 @@ class LevelOverTime(StandardLevelsParent):
             The scale type of the output level. Available options are `"dB"` and `"RMS"`.
         reference_value : float, default: 1.0
             The reference value for the level computation. If the overall level is computed with a
-            signal in Pa, the reference value should be 2e-5.
+            signal in Pa, the reference value should be 2e-5 (Pa).
         frequency_weighting : str, default: ""
             The frequency weighting to apply to the signal before computing the level. Available
-            options are `""`, `"A"`, `"B"`,  and `"C"`, respectively to get level in dBSPL, dB(A),
-            dB(B), and dB(C). Note that the frequency weighting is only applied if the attribute
-            :attr:`scale` is set to `"dB"`.
+            options are `""`, `"A"`, `"B"`,  and `"C"`, to get level in dB (or dBSPL), dBA, dBB,
+            and dBC, respectively. Note that the frequency weighting is only applied if the
+            attribute :attr:`scale` is set to `"dB"`.
         time_weighting : str, default: "Fast"
             The time weighting to use when computing the level over time. Available options are
             `"Fast"`, `"Slow"`, `"Impulse"`, and `"Custom"`. When `"Custom"` is selected, the user
@@ -155,7 +155,7 @@ class LevelOverTime(StandardLevelsParent):
         """Reference value for the level computation.
 
         If the overall level is computed with a sound pressure signal in Pa, the reference value
-        should be 2e-5.
+        should be 2e-5 (Pa).
         """
         return self.__reference_value
 
@@ -171,9 +171,9 @@ class LevelOverTime(StandardLevelsParent):
         """Frequency weighting of the computed level.
 
         Available options are `""`, `"A"`, `"B"`, and `"C"`. If attribute :attr:`reference_value`
-        is 2e-5 Pa, these options allow level calculation in dBSPL, dB(A), dB(B), and dB(C),
-        respectively. Note that the frequency weighting is only applied if the attribute
-        :attr:`scale` is set to `"dB"`.
+        is 2e-5 Pa, these options allow level calculation in dBSPL, dBA, dBB, and dBC, respectively.
+        Note that the frequency weighting is only applied if the attribute :attr:`scale` is set to
+        `"dB"`.
         """
         return self.__frequency_weighting
 

--- a/src/ansys/sound/core/standard_levels/level_over_time.py
+++ b/src/ansys/sound/core/standard_levels/level_over_time.py
@@ -103,8 +103,8 @@ class LevelOverTime(StandardLevelsParent):
         str_frequency_weighting = (
             self.frequency_weighting if len(self.frequency_weighting) > 0 else "None"
         )
-        max_level = self.get_level_max()
-        if max_level is not None:
+        if self._output is not None:
+            max_level = self.get_level_max()
             unit = self.get_output()[1].unit
             str_level = f"{max_level:.1f} {unit}"
         else:

--- a/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
@@ -270,4 +270,5 @@ class OctaveLevelsFromPSD(StandardLevelsParent):
         plt.xticks(rotation=90)
         plt.grid()
         plt.gca().set_axisbelow(True)  # Ensure bars are in front of grid lines
+        plt.tight_layout()
         plt.show()

--- a/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
@@ -1,0 +1,252 @@
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Compute octave levels from a PSD input."""
+import warnings
+
+from ansys.dpf.core import Field, Operator, types
+import matplotlib.pyplot as plt
+import numpy as np
+
+from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from ._standard_levels_parent import DICT_FREQUENCY_WEIGHTING, StandardLevelsParent
+
+ID_OCTAVE_LEVELS_FROM_PSD = "compute_octave_levels_from_psd"
+ID_OCTAVE_LEVELS_FROM_PSD_ANSI = "compute_octave_levels_from_psd_ansi_s1_11_1986"
+ID_GET_FREQUENCY_WEIGHTING = "get_frequency_weighting"
+
+
+class OctaveLevelsFromPSD(StandardLevelsParent):
+    """Compute octave levels from a PSD input.
+
+    This class converts a PSD input signal into octave levels.
+    """
+
+    def __init__(
+        self,
+        psd: Field = None,
+        use_ansi_s1_11_1986: bool = False,
+        reference_value: float = 1.0,
+        frequency_weighting: str = "",
+    ):
+        """Class instantiation takes the following parameters.
+
+        Parameters
+        ----------
+        psd : Field, default: None
+            The power spectral density (PSD) from which the octave levels are computed.
+        use_ansi_s1_11_1986 : bool, default: False
+            Whether to simulate the 1/3-octave filterbank as defined in ANSI S1.11-1986 and
+            IEC 61260 standards.
+        reference_value : float, default: 1.0
+            The reference value for the level computation. If the overall level is computed with a
+            signal in Pa, the reference value should be 2e-5.
+        frequency_weighting : str, default: ""
+            The frequency weighting to apply to the signal before computing the level. Available
+            options are `""`, `"A"`, `"B"`,  and `"C"`, respectively to get level in dBSPL, dB(A),
+            dB(B), and dB(C).
+        """
+        super().__init__()
+        self.psd = psd
+        self.use_ansi_s1_11_1986 = use_ansi_s1_11_1986
+        self.reference_value = reference_value
+        self.frequency_weighting = frequency_weighting
+
+    def __str__(self) -> str:
+        """Return the string representation of the object."""
+        output = self.get_output()
+
+        str_name = f'"{self.signal.name}"' if self.signal is not None else "Not set"
+        str_frequency_weighting = (
+            self.frequency_weighting if len(self.frequency_weighting) > 0 else "None"
+        )
+        str_level = f"{output:.1f}" if output is not None else "Not processed"
+
+        return (
+            f"{__class__.__name__} object.\n"
+            "Data\n"
+            f"\tSignal: {str_name}\n"
+            f"\tScale type: {self.scale}\n"
+            f"\tReference value: {self.reference_value}\n"
+            f"\tFrequency weighting: {str_frequency_weighting}\n"
+            f"Output level value: {str_level}"
+        )
+
+    @property
+    def psd(self) -> Field:
+        """Input PSD."""
+        return self.__psd
+
+    @psd.setter
+    def psd(self, psd: Field):
+        """Set the PSD."""
+        if psd is not None:
+            if not isinstance(psd, Field):
+                raise PyAnsysSoundException("The PSD must be provided as a DPF field.")
+        self.__psd = psd
+
+    @property
+    def use_ansi_s1_11_1986(self) -> bool:
+        """Whether to simulate the octave band filterbank (ANSI S1.11-1986/IEC 61260)."""
+        return self.__use_ansi_s1_11_1986
+
+    @use_ansi_s1_11_1986.setter
+    def use_ansi_s1_11_1986(self, value: bool):
+        """Set the use_ansi_s1_11_1986 flag."""
+        self.__use_ansi_s1_11_1986 = value
+        return self.__use_ansi_s1_11_1986
+
+    @property
+    def reference_value(self) -> float:
+        """Reference value for the level computation.
+
+        If the overall level is computed with a sound pressure signal in Pa, the reference value
+        should be 2e-5.
+        """
+        return self.__reference_value
+
+    @reference_value.setter
+    def reference_value(self, value: float):
+        """Set the reference value."""
+        if value <= 0:
+            raise PyAnsysSoundException("The reference value must be strictly positive.")
+        self.__reference_value = value
+
+    @property
+    def frequency_weighting(self) -> str:
+        """Frequency weighting of the computed level.
+
+        Available options are `""`, `"A"`, `"B"`, and `"C"`. If attribute :attr:`reference_value`
+        is 2e-5 Pa, these options allow level calculation in dBSPL, dB(A), dB(B), and dB(C),
+        respectively.
+        """
+        return self.__frequency_weighting
+
+    @frequency_weighting.setter
+    def frequency_weighting(self, weighting: str):
+        """Set the frequency weighting."""
+        if weighting not in DICT_FREQUENCY_WEIGHTING.keys():
+            raise PyAnsysSoundException(
+                f"The frequency weighting must be one of {list(DICT_FREQUENCY_WEIGHTING.keys())}."
+            )
+        self.__frequency_weighting = weighting
+
+    def process(self):
+        """Compute the overall level."""
+        if self.psd is None:
+            raise PyAnsysSoundException(f"No input PSD is set. Use {__class__.__name__}.psd.")
+
+        if self.use_ansi_s1_11_1986:
+            operator = Operator(ID_OCTAVE_LEVELS_FROM_PSD_ANSI)
+        else:
+            operator = Operator(ID_OCTAVE_LEVELS_FROM_PSD)
+
+        operator.connect(0, self.psd)
+        operator.run()
+        levels: Field = operator.get_output(0, types.field)
+
+        if self.frequency_weighting != "":
+            # Get and apply frequency weighting at the band center frequencies.
+            operator = Operator(ID_GET_FREQUENCY_WEIGHTING)
+            operator.connect(0, levels.time_freq_support.time_frequencies.data)
+            operator.connect(1, self.frequency_weighting)
+            operator.run()
+            levels.data = levels.data * operator.get_output(0, types.vec_double)
+
+        # Convert to dB.
+        levels.data = 10 * np.log10(levels.data / (self.reference_value**2))
+
+        self._output = levels
+
+    def get_output(self) -> Field:
+        """Return the octave levels in dB.
+
+        Returns
+        -------
+        Field
+            The octave levels in dB.
+        """
+        if self._output is None:
+            warnings.warn(
+                PyAnsysSoundWarning(
+                    f"Output is not processed yet. "
+                    f"Use the {__class__.__name__}.process() method."
+                )
+            )
+
+        return self._output
+
+    def get_output_as_nparray(self) -> tuple[np.ndarray]:
+        """Return the octave levels in dB and center frequencies as a tuple of numpy arrays.
+
+        Returns
+        -------
+        np.ndarray
+            The octave levels in dB.
+        np.ndarray
+            The center frequencies of the octave bands.
+        """
+        output = self.get_output()
+
+        if output is None:
+            return (np.array([]), np.array([]))
+
+        return np.array(output.data), np.array([self.time_freq_support.time_frequencies.data])
+
+    def get_one_third_octave_levels(self) -> np.ndarray:
+        """Return the octave levels in dB as a numpy array.
+
+        Returns
+        -------
+        np.ndarray
+            The octave levels in dB.
+        """
+        return self.get_output_as_nparray()[0]
+
+    def get_center_frequencies(self) -> np.ndarray:
+        """Return the center frequencies of the octave bands as a numpy array.
+
+        Returns
+        -------
+        np.ndarray
+            The center frequencies of the octave bands.
+        """
+        return self.get_output_as_nparray()[1]
+
+    def plot(self):
+        """Plot the octave-band levels."""
+        levels, frequencies = self.get_output_as_nparray()
+        freq_str = [str(f) for f in frequencies]
+
+        if self.use_ansi_s1_11_1986:
+            title = "Octave-band levels (ANSI S1.11-1986)"
+        else:
+            title = "Octave-band levels"
+
+        plt.figure()
+        plt.bar(freq_str, levels)
+        plt.title(title)
+        plt.xlabel("Frequency (Hz)")
+        plt.ylabel("Octave-band level (dB)")
+        plt.grid(axis="y")
+        plt.gca().set_axisbelow(True)  # Ensure bars are in front of grid lines
+        plt.show()

--- a/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
@@ -76,10 +76,10 @@ class OctaveLevelsFromPSD(StandardLevelsParent):
         str_name = f'"{self.psd.name}"' if self.psd is not None else "Not set"
         if len(self.frequency_weighting) > 0:
             str_frequency_weighting = self.frequency_weighting
-            str_unit = f"dB{self.frequency_weighting}"
+            str_unit = f"dB{self.frequency_weighting} (re {self.reference_value})"
         else:
             str_frequency_weighting = "None"
-            str_unit = "dB"
+            str_unit = f"dB (re {self.reference_value})"
 
         if self._output is not None:
             str_levels = "\n\t"
@@ -257,10 +257,10 @@ class OctaveLevelsFromPSD(StandardLevelsParent):
         if len(self.frequency_weighting) > 0:
             ylabel = (
                 f"{self.frequency_weighting}-weighted octave-band level "
-                f"(dB{self.frequency_weighting})"
+                f"(dB{self.frequency_weighting} re {self.reference_value})"
             )
         else:
-            ylabel = "Octave-band level (dB)"
+            ylabel = f"Octave-band level (dB re {self.reference_value})"
 
         plt.figure()
         plt.bar(freq_str, levels)

--- a/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
@@ -61,9 +61,9 @@ class OctaveLevelsFromPSD(StandardLevelsParent):
             The reference value for the levels' computation. If the levels are computed with a PSD
             in Pa^2/Hz, the reference value should be 2e-5 (Pa).
         frequency_weighting : str, default: ""
-            The frequency weighting to apply to the signal before computing the levels. Available
-            options are `""`, `"A"`, `"B"`,  and `"C"`, to get levels in dB (or dBSPL), dBA, dBB,
-            and dBC, respectively.
+            The frequency weighting to apply to the computed levels. Available options are `""`,
+            `"A"`, `"B"`,  and `"C"`, to get levels in dB (or dBSPL), dBA, dBB, and dBC,
+            respectively.
         """
         super().__init__()
         self.psd = psd

--- a/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
@@ -38,7 +38,7 @@ ID_GET_FREQUENCY_WEIGHTING = "get_frequency_weighting"
 class OctaveLevelsFromPSD(StandardLevelsParent):
     """Compute octave levels from a PSD input.
 
-    This class converts a PSD input signal into octave levels.
+    This class converts a PSD input into octave levels.
     """
 
     def __init__(

--- a/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Compute octave levels from a PSD input."""
+"""Octave levels from a PSD input."""
 import warnings
 
 from ansys.dpf.core import Field, Operator, types
@@ -105,7 +105,7 @@ class OctaveLevelsFromPSD(StandardLevelsParent):
 
     @property
     def psd(self) -> Field:
-        """Input PSD."""
+        """Input power spectral density (PSD)."""
         return self.__psd
 
     @psd.setter
@@ -125,7 +125,6 @@ class OctaveLevelsFromPSD(StandardLevelsParent):
     def use_ansi_s1_11_1986(self, value: bool):
         """Set the use_ansi_s1_11_1986 flag."""
         self.__use_ansi_s1_11_1986 = value
-        return self.__use_ansi_s1_11_1986
 
     @property
     def reference_value(self) -> float:
@@ -195,7 +194,8 @@ class OctaveLevelsFromPSD(StandardLevelsParent):
         Returns
         -------
         Field
-            The octave levels in dB.
+            The octave levels in dB (actual unit depends on :attr:`reference_value` and
+            :attr:`frequency_weighting` attributes' values).
         """
         if self._output is None:
             warnings.warn(
@@ -208,14 +208,15 @@ class OctaveLevelsFromPSD(StandardLevelsParent):
         return self._output
 
     def get_output_as_nparray(self) -> tuple[np.ndarray]:
-        """Return the octave levels in dB and center frequencies as a tuple of numpy arrays.
+        """Return the octave levels in dB and center frequencies in Hz as numpy arrays.
 
         Returns
         -------
         np.ndarray
-            The octave levels in dB.
+            The octave levels in dB (actual unit depends on :attr:`reference_value` and
+            :attr:`frequency_weighting` attributes' values).
         np.ndarray
-            The center frequencies of the octave bands.
+            The center frequencies in Hz of the octave bands.
         """
         output = self.get_output()
 
@@ -230,17 +231,18 @@ class OctaveLevelsFromPSD(StandardLevelsParent):
         Returns
         -------
         np.ndarray
-            The octave levels in dB.
+            The octave levels in dB (actual unit depends on :attr:`reference_value` and
+            :attr:`frequency_weighting` attributes' values).
         """
         return self.get_output_as_nparray()[0]
 
     def get_center_frequencies(self) -> np.ndarray:
-        """Return the center frequencies of the octave bands as a numpy array.
+        """Return the center frequencies in Hz of the octave bands as a numpy array.
 
         Returns
         -------
         np.ndarray
-            The center frequencies of the octave bands.
+            The center frequencies in Hz of the octave bands.
         """
         return self.get_output_as_nparray()[1]
 

--- a/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
@@ -222,7 +222,7 @@ class OctaveLevelsFromPSD(StandardLevelsParent):
         if output is None:
             return (np.array([]), np.array([]))
 
-        return np.array(output.data), np.array([output.time_freq_support.time_frequencies.data])
+        return np.array(output.data), np.array(output.time_freq_support.time_frequencies.data)
 
     def get_octave_levels(self) -> np.ndarray:
         """Return the octave levels in dB as a numpy array.

--- a/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
@@ -38,7 +38,7 @@ ID_GET_FREQUENCY_WEIGHTING = "get_frequency_weighting"
 class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
     """Compute 1/3-octave levels from a PSD input.
 
-    This class converts a PSD input signal into 1/3-octave levels.
+    This class converts a PSD input into 1/3-octave levels.
     """
 
     def __init__(

--- a/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Compute 1/3-octave levels from a PSD input."""
+"""1/3-octave levels from a PSD input."""
 import warnings
 
 from ansys.dpf.core import Field, Operator, types
@@ -107,7 +107,7 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
 
     @property
     def psd(self) -> Field:
-        """Input PSD."""
+        """Input power spectral density (PSD)."""
         return self.__psd
 
     @psd.setter
@@ -127,7 +127,6 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
     def use_ansi_s1_11_1986(self, value: bool):
         """Set the use_ansi_s1_11_1986 flag."""
         self.__use_ansi_s1_11_1986 = value
-        return self.__use_ansi_s1_11_1986
 
     @property
     def reference_value(self) -> float:
@@ -197,7 +196,8 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
         Returns
         -------
         Field
-            The 1/3-octave levels in dB.
+            The 1/3-octave levels in dB (actual unit depends on :attr:`reference_value` and
+            :attr:`frequency_weighting` attributes' values).
         """
         if self._output is None:
             warnings.warn(
@@ -210,14 +210,15 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
         return self._output
 
     def get_output_as_nparray(self) -> tuple[np.ndarray]:
-        """Return the 1/3-octave levels in dB and center frequencies as a tuple of numpy arrays.
+        """Return the 1/3-octave levels in dB and center frequencies in Hz as numpy arrays.
 
         Returns
         -------
         np.ndarray
-            The 1/3-octave levels in dB.
+            The 1/3-octave levels in dB (actual unit depends on :attr:`reference_value` and
+            :attr:`frequency_weighting` attributes' values).
         np.ndarray
-            The center frequencies of the 1/3-octave bands.
+            The center frequencies in Hz of the 1/3-octave bands.
         """
         output = self.get_output()
 
@@ -232,17 +233,18 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
         Returns
         -------
         np.ndarray
-            The 1/3-octave levels in dB.
+            The 1/3-octave levels in dB (actual unit depends on :attr:`reference_value` and
+            :attr:`frequency_weighting` attributes' values).
         """
         return self.get_output_as_nparray()[0]
 
     def get_center_frequencies(self) -> np.ndarray:
-        """Return the center frequencies of the 1/3-octave bands as a numpy array.
+        """Return the center frequencies in Hz of the 1/3-octave bands as a numpy array.
 
         Returns
         -------
         np.ndarray
-            The center frequencies of the 1/3-octave bands.
+            The center frequencies in Hz of the 1/3-octave bands.
         """
         return self.get_output_as_nparray()[1]
 

--- a/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
@@ -1,0 +1,252 @@
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Compute 1/3-octave levels from a PSD input."""
+import warnings
+
+from ansys.dpf.core import Field, Operator, types
+import matplotlib.pyplot as plt
+import numpy as np
+
+from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from ._standard_levels_parent import DICT_FREQUENCY_WEIGHTING, StandardLevelsParent
+
+ID_THIRD_LEVELS_FROM_PSD = "compute_one_third_octave_levels_from_psd"
+ID_THIRD_LEVELS_FROM_PSD_ANSI = "compute_one_third_octave_levels_from_psd_ansi_s1_11_1986"
+ID_GET_FREQUENCY_WEIGHTING = "get_frequency_weighting"
+
+
+class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
+    """Compute 1/3-octave levels from a PSD input.
+
+    This class converts a PSD input signal into 1/3-octave levels.
+    """
+
+    def __init__(
+        self,
+        psd: Field = None,
+        use_ansi_s1_11_1986: bool = False,
+        reference_value: float = 1.0,
+        frequency_weighting: str = "",
+    ):
+        """Class instantiation takes the following parameters.
+
+        Parameters
+        ----------
+        psd : Field, default: None
+            The power spectral density (PSD) from which the 1/3-octave levels are computed.
+        use_ansi_s1_11_1986 : bool, default: False
+            Whether to simulate the 1/3-octave filterbank as defined in ANSI S1.11-1986 and
+            IEC 61260 standards.
+        reference_value : float, default: 1.0
+            The reference value for the level computation. If the overall level is computed with a
+            signal in Pa, the reference value should be 2e-5.
+        frequency_weighting : str, default: ""
+            The frequency weighting to apply to the signal before computing the level. Available
+            options are `""`, `"A"`, `"B"`,  and `"C"`, respectively to get level in dBSPL, dB(A),
+            dB(B), and dB(C).
+        """
+        super().__init__()
+        self.psd = psd
+        self.use_ansi_s1_11_1986 = use_ansi_s1_11_1986
+        self.reference_value = reference_value
+        self.frequency_weighting = frequency_weighting
+
+    def __str__(self) -> str:
+        """Return the string representation of the object."""
+        output = self.get_output()
+
+        str_name = f'"{self.signal.name}"' if self.signal is not None else "Not set"
+        str_frequency_weighting = (
+            self.frequency_weighting if len(self.frequency_weighting) > 0 else "None"
+        )
+        str_level = f"{output:.1f}" if output is not None else "Not processed"
+
+        return (
+            f"{__class__.__name__} object.\n"
+            "Data\n"
+            f"\tSignal: {str_name}\n"
+            f"\tScale type: {self.scale}\n"
+            f"\tReference value: {self.reference_value}\n"
+            f"\tFrequency weighting: {str_frequency_weighting}\n"
+            f"Output level value: {str_level}"
+        )
+
+    @property
+    def psd(self) -> Field:
+        """Input PSD."""
+        return self.__psd
+
+    @psd.setter
+    def psd(self, psd: Field):
+        """Set the PSD."""
+        if psd is not None:
+            if not isinstance(psd, Field):
+                raise PyAnsysSoundException("The PSD must be provided as a DPF field.")
+        self.__psd = psd
+
+    @property
+    def use_ansi_s1_11_1986(self) -> bool:
+        """Whether to simulate the 1/3-octave band filterbank (ANSI S1.11-1986/IEC 61260)."""
+        return self.__use_ansi_s1_11_1986
+
+    @use_ansi_s1_11_1986.setter
+    def use_ansi_s1_11_1986(self, value: bool):
+        """Set the use_ansi_s1_11_1986 flag."""
+        self.__use_ansi_s1_11_1986 = value
+        return self.__use_ansi_s1_11_1986
+
+    @property
+    def reference_value(self) -> float:
+        """Reference value for the level computation.
+
+        If the overall level is computed with a sound pressure signal in Pa, the reference value
+        should be 2e-5.
+        """
+        return self.__reference_value
+
+    @reference_value.setter
+    def reference_value(self, value: float):
+        """Set the reference value."""
+        if value <= 0:
+            raise PyAnsysSoundException("The reference value must be strictly positive.")
+        self.__reference_value = value
+
+    @property
+    def frequency_weighting(self) -> str:
+        """Frequency weighting of the computed level.
+
+        Available options are `""`, `"A"`, `"B"`, and `"C"`. If attribute :attr:`reference_value`
+        is 2e-5 Pa, these options allow level calculation in dBSPL, dB(A), dB(B), and dB(C),
+        respectively.
+        """
+        return self.__frequency_weighting
+
+    @frequency_weighting.setter
+    def frequency_weighting(self, weighting: str):
+        """Set the frequency weighting."""
+        if weighting not in DICT_FREQUENCY_WEIGHTING.keys():
+            raise PyAnsysSoundException(
+                f"The frequency weighting must be one of {list(DICT_FREQUENCY_WEIGHTING.keys())}."
+            )
+        self.__frequency_weighting = weighting
+
+    def process(self):
+        """Compute the overall level."""
+        if self.psd is None:
+            raise PyAnsysSoundException(f"No input PSD is set. Use {__class__.__name__}.psd.")
+
+        if self.use_ansi_s1_11_1986:
+            operator = Operator(ID_THIRD_LEVELS_FROM_PSD_ANSI)
+        else:
+            operator = Operator(ID_THIRD_LEVELS_FROM_PSD)
+
+        operator.connect(0, self.psd)
+        operator.run()
+        levels: Field = operator.get_output(0, types.field)
+
+        if self.frequency_weighting != "":
+            # Get and apply frequency weighting at the band center frequencies.
+            operator = Operator(ID_GET_FREQUENCY_WEIGHTING)
+            operator.connect(0, levels.time_freq_support.time_frequencies.data)
+            operator.connect(1, self.frequency_weighting)
+            operator.run()
+            levels.data = levels.data * operator.get_output(0, types.vec_double)
+
+        # Convert to dB.
+        levels.data = 10 * np.log10(levels.data / (self.reference_value**2))
+
+        self._output = levels
+
+    def get_output(self) -> Field:
+        """Return the 1/3-octave levels in dB.
+
+        Returns
+        -------
+        Field
+            The 1/3-octave levels in dB.
+        """
+        if self._output is None:
+            warnings.warn(
+                PyAnsysSoundWarning(
+                    f"Output is not processed yet. "
+                    f"Use the {__class__.__name__}.process() method."
+                )
+            )
+
+        return self._output
+
+    def get_output_as_nparray(self) -> tuple[np.ndarray]:
+        """Return the 1/3-octave levels in dB and center frequencies as a tuple of numpy arrays.
+
+        Returns
+        -------
+        np.ndarray
+            The 1/3-octave levels in dB.
+        np.ndarray
+            The center frequencies of the 1/3-octave bands.
+        """
+        output = self.get_output()
+
+        if output is None:
+            return (np.array([]), np.array([]))
+
+        return np.array(output.data), np.array([self.time_freq_support.time_frequencies.data])
+
+    def get_one_third_octave_levels(self) -> np.ndarray:
+        """Return the 1/3-octave levels in dB as a numpy array.
+
+        Returns
+        -------
+        np.ndarray
+            The 1/3-octave levels in dB.
+        """
+        return self.get_output_as_nparray()[0]
+
+    def get_center_frequencies(self) -> np.ndarray:
+        """Return the center frequencies of the 1/3-octave bands as a numpy array.
+
+        Returns
+        -------
+        np.ndarray
+            The center frequencies of the 1/3-octave bands.
+        """
+        return self.get_output_as_nparray()[1]
+
+    def plot(self):
+        """Plot the 1/3-octave-band levels."""
+        levels, frequencies = self.get_output_as_nparray()
+        freq_str = [str(f) for f in frequencies]
+
+        if self.use_ansi_s1_11_1986:
+            title = "1/3-octave-band levels (ANSI S1.11-1986)"
+        else:
+            title = "1/3-octave-band levels"
+
+        plt.figure()
+        plt.bar(freq_str, levels)
+        plt.title(title)
+        plt.xlabel("Frequency (Hz)")
+        plt.ylabel("1/3-octave-band level (dB)")
+        plt.grid(axis="y")
+        plt.gca().set_axisbelow(True)  # Ensure bars are in front of grid lines
+        plt.show()

--- a/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
@@ -58,12 +58,12 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
             Whether to simulate the 1/3-octave filterbank as defined in ANSI S1.11-1986 and
             IEC 61260 standards.
         reference_value : float, default: 1.0
-            The reference value for the level computation. If the overall level is computed with a
-            signal in Pa, the reference value should be 2e-5.
+            The reference value for the levels' computation. If the levels are computed with a PSD
+            in Pa^2/Hz, the reference value should be 2e-5 (Pa).
         frequency_weighting : str, default: ""
-            The frequency weighting to apply to the signal before computing the level. Available
-            options are `""`, `"A"`, `"B"`,  and `"C"`, respectively to get level in dBSPL, dB(A),
-            dB(B), and dB(C).
+            The frequency weighting to apply to the computed levels. Available options are `""`,
+            `"A"`, `"B"`,  and `"C"`, to get levels in dB (or dBSPL), dBA, dBB, and dBC,
+            respectively.
         """
         super().__init__()
         self.psd = psd
@@ -73,22 +73,36 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
 
     def __str__(self) -> str:
         """Return the string representation of the object."""
-        output = self.get_output()
+        str_name = f'"{self.psd.name}"' if self.psd is not None else "Not set"
+        if len(self.frequency_weighting) > 0:
+            str_frequency_weighting = self.frequency_weighting
+            str_unit = f"dB{self.frequency_weighting}"
+        else:
+            str_frequency_weighting = "None"
+            str_unit = "dB"
 
-        str_name = f'"{self.signal.name}"' if self.signal is not None else "Not set"
-        str_frequency_weighting = (
-            self.frequency_weighting if len(self.frequency_weighting) > 0 else "None"
-        )
-        str_level = f"{output:.1f}" if output is not None else "Not processed"
+        if self._output is not None:
+            str_levels = "\n\t"
+            str_levels += "\n\t".join(
+                [
+                    f"{f:.1f} Hz:\t{l:.1f} {str_unit}"
+                    for (f, l) in zip(
+                        self.get_center_frequencies(), self.get_one_third_octave_levels()
+                    )
+                ]
+            )
+        else:
+            str_levels = " Not processed"
 
         return (
             f"{__class__.__name__} object.\n"
             "Data\n"
-            f"\tSignal: {str_name}\n"
-            f"\tScale type: {self.scale}\n"
+            f"\tPSD: {str_name}\n"
+            f"\tANSI S1.11-1986 filterbank simulation: "
+            f"{'Yes' if self.use_ansi_s1_11_1986 else 'No'}\n"
             f"\tReference value: {self.reference_value}\n"
             f"\tFrequency weighting: {str_frequency_weighting}\n"
-            f"Output level value: {str_level}"
+            f"Output levels:{str_levels}"
         )
 
     @property
@@ -117,10 +131,9 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
 
     @property
     def reference_value(self) -> float:
-        """Reference value for the level computation.
+        """Reference value for the levels' computation.
 
-        If the overall level is computed with a sound pressure signal in Pa, the reference value
-        should be 2e-5.
+        If the levels are computed with a PSD in Pa^2/Hz, the reference value should be 2e-5 (Pa).
         """
         return self.__reference_value
 
@@ -133,11 +146,10 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
 
     @property
     def frequency_weighting(self) -> str:
-        """Frequency weighting of the computed level.
+        """Frequency weighting of the computed levels.
 
-        Available options are `""`, `"A"`, `"B"`, and `"C"`. If attribute :attr:`reference_value`
-        is 2e-5 Pa, these options allow level calculation in dBSPL, dB(A), dB(B), and dB(C),
-        respectively.
+        Available options are `""`, `"A"`, `"B"`, and `"C"`, allowing level calculation in dB (or
+        dBSPL), dBA, dBB, and dBC, respectively.
         """
         return self.__frequency_weighting
 
@@ -151,7 +163,7 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
         self.__frequency_weighting = weighting
 
     def process(self):
-        """Compute the overall level."""
+        """Compute the 1/3-octave-band levels."""
         if self.psd is None:
             raise PyAnsysSoundException(f"No input PSD is set. Use {__class__.__name__}.psd.")
 
@@ -164,16 +176,18 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
         operator.run()
         levels: Field = operator.get_output(0, types.field)
 
-        if self.frequency_weighting != "":
+        if len(self.frequency_weighting) > 0:
             # Get and apply frequency weighting at the band center frequencies.
             operator = Operator(ID_GET_FREQUENCY_WEIGHTING)
             operator.connect(0, levels.time_freq_support.time_frequencies.data)
             operator.connect(1, self.frequency_weighting)
             operator.run()
-            levels.data = levels.data * operator.get_output(0, types.vec_double)
+            weights_dB = operator.get_output(0, types.vec_double)
+            weights = 10 ** (weights_dB / 10)
+            levels.data = levels.data * weights
 
         # Convert to dB.
-        levels.data = 10 * np.log10(levels.data / (self.reference_value**2))
+        levels.data = 10 * np.log10(levels.data / (self.reference_value**2) + 1e-12)
 
         self._output = levels
 
@@ -210,7 +224,7 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
         if output is None:
             return (np.array([]), np.array([]))
 
-        return np.array(output.data), np.array([self.time_freq_support.time_frequencies.data])
+        return np.array(output.data), np.array(output.time_freq_support.time_frequencies.data)
 
     def get_one_third_octave_levels(self) -> np.ndarray:
         """Return the 1/3-octave levels in dB as a numpy array.
@@ -242,11 +256,20 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
         else:
             title = "1/3-octave-band levels"
 
+        if len(self.frequency_weighting) > 0:
+            ylabel = (
+                f"{self.frequency_weighting}-weighted 1/3octave-band level "
+                f"(dB{self.frequency_weighting})"
+            )
+        else:
+            ylabel = "1/3-octave-band level (dB)"
+
         plt.figure()
         plt.bar(freq_str, levels)
         plt.title(title)
         plt.xlabel("Frequency (Hz)")
-        plt.ylabel("1/3-octave-band level (dB)")
-        plt.grid(axis="y")
+        plt.ylabel(ylabel)
+        plt.xticks(rotation=90)
+        plt.grid()
         plt.gca().set_axisbelow(True)  # Ensure bars are in front of grid lines
         plt.show()

--- a/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
@@ -76,10 +76,10 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
         str_name = f'"{self.psd.name}"' if self.psd is not None else "Not set"
         if len(self.frequency_weighting) > 0:
             str_frequency_weighting = self.frequency_weighting
-            str_unit = f"dB{self.frequency_weighting}"
+            str_unit = f"dB{self.frequency_weighting} (re {self.reference_value})"
         else:
             str_frequency_weighting = "None"
-            str_unit = "dB"
+            str_unit = f"dB (re {self.reference_value})"
 
         if self._output is not None:
             str_levels = "\n\t"
@@ -259,10 +259,10 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
         if len(self.frequency_weighting) > 0:
             ylabel = (
                 f"{self.frequency_weighting}-weighted 1/3octave-band level "
-                f"(dB{self.frequency_weighting})"
+                f"(dB{self.frequency_weighting} re {self.reference_value})"
             )
         else:
-            ylabel = "1/3-octave-band level (dB)"
+            ylabel = f"1/3-octave-band level (dB re {self.reference_value})"
 
         plt.figure()
         plt.bar(freq_str, levels)

--- a/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/one_third_octave_levels_from_psd.py
@@ -272,4 +272,5 @@ class OneThirdOctaveLevelsFromPSD(StandardLevelsParent):
         plt.xticks(rotation=90)
         plt.grid()
         plt.gca().set_axisbelow(True)  # Ensure bars are in front of grid lines
+        plt.tight_layout()
         plt.show()

--- a/src/ansys/sound/core/standard_levels/overall_level.py
+++ b/src/ansys/sound/core/standard_levels/overall_level.py
@@ -55,11 +55,11 @@ class OverallLevel(StandardLevelsParent):
             The scale type of the output level. Available options are `"dB"` and `"RMS"`.
         reference_value : float, default: 1.0
             The reference value for the level computation. If the overall level is computed with a
-            signal in Pa, the reference value should be 2e-5.
+            signal in Pa, the reference value should be 2e-5 (Pa).
         frequency_weighting : str, default: ""
             The frequency weighting to apply to the signal before computing the level. Available
-            options are `""`, `"A"`, `"B"`,  and `"C"`, respectively to get level in dBSPL, dB(A),
-            dB(B), and dB(C). Note that the frequency weighting is only applied if the attribute
+            options are `""`, `"A"`, `"B"`,  and `"C"`, respectively to get level in dB (or dBSPL),
+            dBA, dBB, and dBC. Note that the frequency weighting is only applied if the attribute
             :attr:`scale` is set to `"dB"`.
         """
         super().__init__()
@@ -71,13 +71,14 @@ class OverallLevel(StandardLevelsParent):
 
     def __str__(self) -> str:
         """Return the string representation of the object."""
-        output = self.get_output()
-
         str_name = f'"{self.signal.name}"' if self.signal is not None else "Not set"
-        str_frequency_weighting = (
-            self.frequency_weighting if len(self.frequency_weighting) > 0 else "None"
-        )
-        str_level = f"{output:.1f}" if output is not None else "Not processed"
+        if len(self.frequency_weighting) > 0:
+            str_frequency_weighting = self.frequency_weighting
+            unit = f"dB{self.frequency_weighting} (re {self.reference_value})"
+        else:
+            str_frequency_weighting = "None"
+            unit = f"dB (re {self.reference_value})"
+        str_level = f"{self._output:.1f} {unit}" if self._output is not None else "Not processed"
 
         return (
             f"{__class__.__name__} object.\n"
@@ -123,7 +124,7 @@ class OverallLevel(StandardLevelsParent):
         """Reference value for the level computation.
 
         If the overall level is computed with a sound pressure signal in Pa, the reference value
-        should be 2e-5.
+        should be 2e-5 (Pa).
         """
         return self.__reference_value
 
@@ -139,9 +140,9 @@ class OverallLevel(StandardLevelsParent):
         """Frequency weighting of the computed level.
 
         Available options are `""`, `"A"`, `"B"`, and `"C"`. If attribute :attr:`reference_value`
-        is 2e-5 Pa, these options allow level calculation in dBSPL, dB(A), dB(B), and dB(C),
-        respectively. Note that the frequency weighting is only applied if the attribute
-        :attr:`scale` is set to `"dB"`.
+        is 2e-5 Pa, these options allow level calculation in dBSPL, dBA, dBB, and dBC, respectively.
+        Note that the frequency weighting is only applied if the attribute :attr:`scale` is set to
+        `"dB"`.
         """
         return self.__frequency_weighting
 

--- a/tests/tests_standard_levels/test_standard_levels_level_over_time.py
+++ b/tests/tests_standard_levels/test_standard_levels_level_over_time.py
@@ -117,11 +117,7 @@ def test_level_over_time_properties_exceptions():
 def test_level_over_time___str__():
     """Test LevelOverTime __str__ method."""
     level_obj = LevelOverTime()
-    with pytest.warns(
-        PyAnsysSoundWarning,
-        match="Output is not processed yet. Use the LevelOverTime.process\\(\\) method.",
-    ):
-        assert str(level_obj) == EXP_STR_NOT_SET
+    assert str(level_obj) == EXP_STR_NOT_SET
 
     loader = LoadWav(pytest.data_path_flute_nonUnitaryCalib_in_container)
     loader.process()
@@ -129,11 +125,7 @@ def test_level_over_time___str__():
 
     level_obj.signal = f_signal
     level_obj.set_custom_parameters(time_step=100.0, window_size=5000.0, analysis_window="HANN")
-    with pytest.warns(
-        PyAnsysSoundWarning,
-        match="Output is not processed yet. Use the LevelOverTime.process\\(\\) method.",
-    ):
-        assert str(level_obj) == EXP_STR_ALL_SET
+    assert str(level_obj) == EXP_STR_ALL_SET
 
     level_obj.reference_value = 2e-5
     level_obj.process()

--- a/tests/tests_standard_levels/test_standard_levels_octave_levels_from_psd.py
+++ b/tests/tests_standard_levels/test_standard_levels_octave_levels_from_psd.py
@@ -1,0 +1,320 @@
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from unittest.mock import patch
+
+from ansys.dpf.core import Field, TimeFreqSupport, fields_factory, locations
+import numpy as np
+import pytest
+
+from ansys.sound.core._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from ansys.sound.core.standard_levels import OctaveLevelsFromPSD
+
+EXP_STR_NOT_SET = (
+    "OctaveLevelsFromPSD object.\nData\n\tPSD: Not set\n"
+    "\tANSI S1.11-1986 filterbank simulation: No\n\tReference value: 1.0\n"
+    "\tFrequency weighting: None\nOutput levels: Not processed"
+)
+EXP_STR_ALL_SET = (
+    'OctaveLevelsFromPSD object.\nData\n\tPSD: "Name of the PSD"\n'
+    "\tANSI S1.11-1986 filterbank simulation: Yes\n\tReference value: 2e-05\n"
+    "\tFrequency weighting: A\nOutput levels: Not processed"
+)
+EXP_STR_ALL_PROCESSED = (
+    'OctaveLevelsFromPSD object.\nData\n\tPSD: "Name of the PSD"\n'
+    "\tANSI S1.11-1986 filterbank simulation: Yes\n\tReference value: 2e-05\n"
+    "\tFrequency weighting: A\nOutput levels:\n"
+    "\t31.5 Hz:\t-28.5 dBA (re 2e-05)\n"
+    "\t63.0 Hz:\t-2.6 dBA (re 2e-05)\n"
+    "\t125.0 Hz:\t19.2 dBA (re 2e-05)\n"
+    "\t250.0 Hz:\t62.6 dBA (re 2e-05)\n"
+    "\t500.0 Hz:\t76.3 dBA (re 2e-05)\n"
+    "\t1000.0 Hz:\t77.7 dBA (re 2e-05)\n"
+    "\t2000.0 Hz:\t75.8 dBA (re 2e-05)\n"
+    "\t4000.0 Hz:\t54.7 dBA (re 2e-05)\n"
+    "\t8000.0 Hz:\t44.7 dBA (re 2e-05)\n"
+    "\t16000.0 Hz:\t31.2 dBA (re 2e-05)"
+)
+EXP_BAND_COUNT = 10
+EXP_LEVEL_DEFAULT_0 = -83.20694
+EXP_LEVEL_DEFAULT_3 = -22.85120
+EXP_LEVEL_DEFAULT_5 = -16.37535
+EXP_LEVEL_DEFAULT_7 = -40.26423
+EXP_LEVEL_DEFAULT_9 = -56.69872
+EXP_LEVEL_ANSI_A_PA_0 = -28.49408
+EXP_LEVEL_ANSI_A_PA_3 = 62.58681
+EXP_LEVEL_ANSI_A_PA_5 = 77.67242
+EXP_LEVEL_ANSI_A_PA_7 = 54.71013
+EXP_LEVEL_ANSI_A_PA_9 = 31.18168
+EXP_LEVEL_ANSI_B_PA_0 = -6.09066
+EXP_LEVEL_ANSI_B_PA_3 = 69.90167
+EXP_LEVEL_ANSI_B_PA_5 = 77.67242
+EXP_LEVEL_ANSI_B_PA_7 = 53.02160
+EXP_LEVEL_ANSI_B_PA_9 = 29.36048
+EXP_LEVEL_ANSI_C_PA_0 = 8.00419
+EXP_LEVEL_ANSI_C_PA_3 = 71.26126
+EXP_LEVEL_ANSI_C_PA_5 = 77.67242
+EXP_LEVEL_ANSI_C_PA_7 = 52.92066
+EXP_LEVEL_ANSI_C_PA_9 = 29.25315
+EXP_FREQUENCY_0 = 31.5
+EXP_FREQUENCY_3 = 250.0
+EXP_FREQUENCY_5 = 1000.0
+EXP_FREQUENCY_7 = 4000.0
+EXP_FREQUENCY_9 = 16000.0
+
+
+@pytest.fixture
+def create_psd_from_txt_data():
+    path_flute_psd = pytest.data_path_flute_psd_locally
+
+    # Open a txt file for reading
+    fid = open(path_flute_psd)
+
+    # skip first line
+    fid.readline()
+
+    # read all other lines
+    all_lines = fid.readlines()
+    # close file
+    fid.close()
+
+    amplitudes = []
+
+    for line in all_lines:
+        splitted_line = line.split()
+        amplitudes.append(float(splitted_line[1]))
+
+    amplitudes = np.array(amplitudes)
+
+    # convert dBSPL / Hz -> Pa^2/Hz
+    amplitudes = np.power(10, amplitudes / 10)
+    amplitudes = amplitudes * 2.0e-5
+    amplitudes = amplitudes * 2.0e-5
+
+    # for now, due to a sharp constraint on regularity of frequencies (1.0e-5) in the operator,
+    # we cannot use those written in the file. Let's recreate them
+    frequencies = np.linspace(0, 22050, len(amplitudes))
+
+    psd = fields_factory.create_scalar_field(num_entities=1, location=locations.time_freq)
+    psd.append(amplitudes, 1)
+    support = TimeFreqSupport()
+    frequencies_field = fields_factory.create_scalar_field(
+        num_entities=1, location=locations.time_freq
+    )
+    frequencies_field.append(frequencies, 1)
+    support.time_frequencies = frequencies_field
+
+    psd.time_freq_support = support
+
+    yield psd
+
+
+def test_octave_levels_from_psd_instantiation():
+    """Test OctaveLevelsFromPSD instantiation."""
+    level_obj = OctaveLevelsFromPSD()
+    assert level_obj.psd == None
+    assert level_obj.use_ansi_s1_11_1986 == False
+    assert level_obj.reference_value == 1.0
+    assert level_obj.frequency_weighting == ""
+
+
+def test_octave_levels_from_psd_properties():
+    """Test OctaveLevelsFromPSD properties."""
+    level_obj = OctaveLevelsFromPSD()
+    level_obj.psd = Field()
+    assert type(level_obj.psd) == Field
+
+    level_obj.use_ansi_s1_11_1986 = True
+    assert level_obj.use_ansi_s1_11_1986 == True
+
+    level_obj.reference_value = 2e-5
+    assert level_obj.reference_value == 2e-5
+
+    level_obj.frequency_weighting = "A"
+    assert level_obj.frequency_weighting == "A"
+
+
+def test_octave_levels_from_psd_properties_exceptions():
+    """Test OctaveLevelsFromPSD properties exceptions."""
+    level_obj = OctaveLevelsFromPSD()
+    with pytest.raises(PyAnsysSoundException, match="The PSD must be provided as a DPF field."):
+        level_obj.psd = "InvalidType"
+
+    with pytest.raises(
+        PyAnsysSoundException, match="The reference value must be strictly positive."
+    ):
+        level_obj.reference_value = -1
+
+    with pytest.raises(
+        PyAnsysSoundException,
+        match="The frequency weighting must be one of \\['', 'A', 'B', 'C'\\].",
+    ):
+        level_obj.frequency_weighting = "Invalid"
+
+
+def test_octave_levels_from_psd___str__(create_psd_from_txt_data):
+    """Test OctaveLevelsFromPSD __str__ method."""
+    level_obj = OctaveLevelsFromPSD()
+    assert str(level_obj) == EXP_STR_NOT_SET
+
+    psd = create_psd_from_txt_data
+    psd.name = "Name of the PSD"
+
+    level_obj.psd = psd
+    level_obj.use_ansi_s1_11_1986 = True
+    level_obj.reference_value = 2e-5
+    level_obj.frequency_weighting = "A"
+    assert str(level_obj) == EXP_STR_ALL_SET
+
+    level_obj.process()
+    assert str(level_obj) == EXP_STR_ALL_PROCESSED
+
+
+def test_octave_levels_from_psd_process(create_psd_from_txt_data):
+    """Test OctaveLevelsFromPSD process method."""
+    level_obj = OctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    level_obj.process()
+    assert level_obj._output is not None
+
+
+def test_octave_levels_from_psd_process_exceptions():
+    """Test OctaveLevelsFromPSD process method exceptions."""
+    level_obj = OctaveLevelsFromPSD()
+    with pytest.raises(
+        PyAnsysSoundException,
+        match="No input PSD is set. Use OctaveLevelsFromPSD.psd.",
+    ):
+        level_obj.process()
+
+
+def test_octave_levels_from_psd_get_output(create_psd_from_txt_data):
+    """Test OctaveLevelsFromPSD get_output method."""
+    level_obj = OctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    level_obj.process()
+    output = level_obj.get_output()
+    assert isinstance(output, Field)
+
+
+def test_octave_levels_from_psd_get_output_warnings():
+    """Test OctaveLevelsFromPSD get_output method warnings."""
+    level_obj = OctaveLevelsFromPSD()
+    with pytest.warns(
+        PyAnsysSoundWarning,
+        match="Output is not processed yet. Use the OctaveLevelsFromPSD.process\\(\\) method.",
+    ):
+        output = level_obj.get_output()
+    assert output is None
+
+
+def test_octave_levels_from_psd_get_output_as_nparray(create_psd_from_txt_data):
+    """Test OctaveLevelsFromPSD get_output_as_nparray method."""
+    level_obj = OctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    with pytest.warns(
+        PyAnsysSoundWarning,
+        match="Output is not processed yet. Use the OctaveLevelsFromPSD.process\\(\\) method.",
+    ):
+        levels, frequencies = level_obj.get_output_as_nparray()
+    assert isinstance(levels, np.ndarray)
+    assert len(levels) == 0
+    assert isinstance(frequencies, np.ndarray)
+    assert len(frequencies) == 0
+
+    level_obj.process()
+    levels, frequencies = level_obj.get_output_as_nparray()
+    assert isinstance(levels, np.ndarray)
+    assert len(levels) == EXP_BAND_COUNT
+    assert isinstance(frequencies, np.ndarray)
+    assert len(frequencies) == EXP_BAND_COUNT
+
+
+def test_octave_levels_from_psd_get_octave_levels(create_psd_from_txt_data):
+    """Test OctaveLevelsFromPSD get_octave_levels method."""
+    level_obj = OctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    level_obj.process()
+    levels = level_obj.get_octave_levels()
+    assert isinstance(levels, np.ndarray)
+    assert len(levels) == EXP_BAND_COUNT
+    assert levels[0] == pytest.approx(EXP_LEVEL_DEFAULT_0)
+    assert levels[3] == pytest.approx(EXP_LEVEL_DEFAULT_3)
+    assert levels[5] == pytest.approx(EXP_LEVEL_DEFAULT_5)
+    assert levels[7] == pytest.approx(EXP_LEVEL_DEFAULT_7)
+    assert levels[9] == pytest.approx(EXP_LEVEL_DEFAULT_9)
+
+    level_obj.use_ansi_s1_11_1986 = True
+    level_obj.frequency_weighting = "A"
+    level_obj.reference_value = 2e-5
+    level_obj.process()
+
+    levels = level_obj.get_octave_levels()
+    assert levels[0] == pytest.approx(EXP_LEVEL_ANSI_A_PA_0)
+    assert levels[3] == pytest.approx(EXP_LEVEL_ANSI_A_PA_3)
+    assert levels[5] == pytest.approx(EXP_LEVEL_ANSI_A_PA_5)
+    assert levels[7] == pytest.approx(EXP_LEVEL_ANSI_A_PA_7)
+    assert levels[9] == pytest.approx(EXP_LEVEL_ANSI_A_PA_9)
+
+    level_obj.frequency_weighting = "B"
+    level_obj.process()
+
+    levels = level_obj.get_octave_levels()
+    assert levels[0] == pytest.approx(EXP_LEVEL_ANSI_B_PA_0)
+    assert levels[3] == pytest.approx(EXP_LEVEL_ANSI_B_PA_3)
+    assert levels[5] == pytest.approx(EXP_LEVEL_ANSI_B_PA_5)
+    assert levels[7] == pytest.approx(EXP_LEVEL_ANSI_B_PA_7)
+    assert levels[9] == pytest.approx(EXP_LEVEL_ANSI_B_PA_9)
+
+    level_obj.frequency_weighting = "C"
+    level_obj.process()
+
+    levels = level_obj.get_octave_levels()
+    assert levels[0] == pytest.approx(EXP_LEVEL_ANSI_C_PA_0)
+    assert levels[3] == pytest.approx(EXP_LEVEL_ANSI_C_PA_3)
+    assert levels[5] == pytest.approx(EXP_LEVEL_ANSI_C_PA_5)
+    assert levels[7] == pytest.approx(EXP_LEVEL_ANSI_C_PA_7)
+    assert levels[9] == pytest.approx(EXP_LEVEL_ANSI_C_PA_9)
+
+
+def test_octave_levels_from_psd_get_frequencies(create_psd_from_txt_data):
+    """Test OctaveLevelsFromPSD get_frequencies method."""
+    level_obj = OctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    level_obj.process()
+    frequencies = level_obj.get_center_frequencies()
+    assert isinstance(frequencies, np.ndarray)
+    assert len(frequencies) == EXP_BAND_COUNT
+    assert frequencies[0] == pytest.approx(EXP_FREQUENCY_0)
+    assert frequencies[3] == pytest.approx(EXP_FREQUENCY_3)
+    assert frequencies[5] == pytest.approx(EXP_FREQUENCY_5)
+    assert frequencies[7] == pytest.approx(EXP_FREQUENCY_7)
+    assert frequencies[9] == pytest.approx(EXP_FREQUENCY_9)
+
+
+@patch("matplotlib.pyplot.show")
+def test_octave_levels_from_psd_plot(mock_show, create_psd_from_txt_data):
+    """Test OctaveLevelsFromPSD plot method."""
+    level_obj = OctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    level_obj.process()
+    level_obj.plot()
+
+    level_obj.use_ansi_s1_11_1986 = True
+    level_obj.frequency_weighting = "A"
+    level_obj.reference_value = 2e-5
+    level_obj.process()
+    level_obj.plot()

--- a/tests/tests_standard_levels/test_standard_levels_one_third_octave_levels_from_psd.py
+++ b/tests/tests_standard_levels/test_standard_levels_one_third_octave_levels_from_psd.py
@@ -1,0 +1,343 @@
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from unittest.mock import patch
+
+from ansys.dpf.core import Field, TimeFreqSupport, fields_factory, locations
+import numpy as np
+import pytest
+
+from ansys.sound.core._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from ansys.sound.core.standard_levels import OneThirdOctaveLevelsFromPSD
+
+EXP_STR_NOT_SET = (
+    "OneThirdOctaveLevelsFromPSD object.\nData\n\tPSD: Not set\n"
+    "\tANSI S1.11-1986 filterbank simulation: No\n\tReference value: 1.0\n"
+    "\tFrequency weighting: None\nOutput levels: Not processed"
+)
+EXP_STR_ALL_SET = (
+    'OneThirdOctaveLevelsFromPSD object.\nData\n\tPSD: "Name of the PSD"\n'
+    "\tANSI S1.11-1986 filterbank simulation: Yes\n\tReference value: 2e-05\n"
+    "\tFrequency weighting: A\nOutput levels: Not processed"
+)
+EXP_STR_ALL_PROCESSED = (
+    'OneThirdOctaveLevelsFromPSD object.\nData\n\tPSD: "Name of the PSD"\n'
+    "\tANSI S1.11-1986 filterbank simulation: Yes\n\tReference value: 2e-05\n"
+    "\tFrequency weighting: A\nOutput levels:\n"
+    "\t25.0 Hz:\t-45.7 dBA (re 2e-05)\n"
+    "\t31.5 Hz:\t-36.6 dBA (re 2e-05)\n"
+    "\t40.0 Hz:\t-24.6 dBA (re 2e-05)\n"
+    "\t50.0 Hz:\t-16.4 dBA (re 2e-05)\n"
+    "\t63.0 Hz:\t-10.2 dBA (re 2e-05)\n"
+    "\t80.0 Hz:\t-0.2 dBA (re 2e-05)\n"
+    "\t100.0 Hz:\t6.2 dBA (re 2e-05)\n"
+    "\t125.0 Hz:\t13.3 dBA (re 2e-05)\n"
+    "\t160.0 Hz:\t20.3 dBA (re 2e-05)\n"
+    "\t200.0 Hz:\t37.0 dBA (re 2e-05)\n"
+    "\t250.0 Hz:\t62.4 dBA (re 2e-05)\n"
+    "\t315.0 Hz:\t50.9 dBA (re 2e-05)\n"
+    "\t400.0 Hz:\t51.1 dBA (re 2e-05)\n"
+    "\t500.0 Hz:\t76.0 dBA (re 2e-05)\n"
+    "\t630.0 Hz:\t64.6 dBA (re 2e-05)\n"
+    "\t800.0 Hz:\t76.1 dBA (re 2e-05)\n"
+    "\t1000.0 Hz:\t68.4 dBA (re 2e-05)\n"
+    "\t1250.0 Hz:\t63.7 dBA (re 2e-05)\n"
+    "\t1600.0 Hz:\t71.6 dBA (re 2e-05)\n"
+    "\t2000.0 Hz:\t73.5 dBA (re 2e-05)\n"
+    "\t2500.0 Hz:\t59.7 dBA (re 2e-05)\n"
+    "\t3150.0 Hz:\t51.9 dBA (re 2e-05)\n"
+    "\t4000.0 Hz:\t50.7 dBA (re 2e-05)\n"
+    "\t5000.0 Hz:\t44.5 dBA (re 2e-05)\n"
+    "\t6300.0 Hz:\t42.6 dBA (re 2e-05)\n"
+    "\t8000.0 Hz:\t39.4 dBA (re 2e-05)\n"
+    "\t10000.0 Hz:\t36.8 dBA (re 2e-05)\n"
+    "\t12500.0 Hz:\t33.2 dBA (re 2e-05)\n"
+    "\t16000.0 Hz:\t21.4 dBA (re 2e-05)"
+)
+EXP_BAND_COUNT = 29
+EXP_LEVEL_DEFAULT_16 = -25.79320
+EXP_LEVEL_DEFAULT_15 = -17.04215
+EXP_LEVEL_DEFAULT_17 = -31.90580
+EXP_LEVEL_DEFAULT_9 = -66.79136
+EXP_LEVEL_DEFAULT_21 = -43.38078
+EXP_LEVEL_ANSI_A_PA_16 = 68.44873
+EXP_LEVEL_ANSI_A_PA_15 = 76.14687
+EXP_LEVEL_ANSI_A_PA_17 = 63.72639
+EXP_LEVEL_ANSI_A_PA_9 = 36.97804
+EXP_LEVEL_ANSI_A_PA_21 = 51.93572
+EXP_LEVEL_ANSI_B_PA_16 = 68.44873
+EXP_LEVEL_ANSI_B_PA_15 = 76.90100
+EXP_LEVEL_ANSI_B_PA_17 = 63.15748
+EXP_LEVEL_ANSI_B_PA_9 = 45.78420
+EXP_LEVEL_ANSI_B_PA_21 = 50.33163
+EXP_LEVEL_ANSI_C_PA_16 = 68.44873
+EXP_LEVEL_ANSI_C_PA_15 = 76.96046
+EXP_LEVEL_ANSI_C_PA_17 = 63.11899
+EXP_LEVEL_ANSI_C_PA_9 = 47.79314
+EXP_LEVEL_ANSI_C_PA_21 = 50.23485
+EXP_FREQUENCY_16 = 1000.0
+EXP_FREQUENCY_15 = 800.0
+EXP_FREQUENCY_17 = 1250.0
+EXP_FREQUENCY_9 = 200.0
+EXP_FREQUENCY_21 = 3150.0
+
+
+@pytest.fixture
+def create_psd_from_txt_data():
+    path_flute_psd = pytest.data_path_flute_psd_locally
+
+    # Open a txt file for reading
+    fid = open(path_flute_psd)
+
+    # skip first line
+    fid.readline()
+
+    # read all other lines
+    all_lines = fid.readlines()
+    # close file
+    fid.close()
+
+    amplitudes = []
+
+    for line in all_lines:
+        splitted_line = line.split()
+        amplitudes.append(float(splitted_line[1]))
+
+    amplitudes = np.array(amplitudes)
+
+    # convert dBSPL / Hz -> Pa^2/Hz
+    amplitudes = np.power(10, amplitudes / 10)
+    amplitudes = amplitudes * 2.0e-5
+    amplitudes = amplitudes * 2.0e-5
+
+    # for now, due to a sharp constraint on regularity of frequencies (1.0e-5) in the operator,
+    # we cannot use those written in the file. Let's recreate them
+    frequencies = np.linspace(0, 22050, len(amplitudes))
+
+    psd = fields_factory.create_scalar_field(num_entities=1, location=locations.time_freq)
+    psd.append(amplitudes, 1)
+    support = TimeFreqSupport()
+    frequencies_field = fields_factory.create_scalar_field(
+        num_entities=1, location=locations.time_freq
+    )
+    frequencies_field.append(frequencies, 1)
+    support.time_frequencies = frequencies_field
+
+    psd.time_freq_support = support
+
+    yield psd
+
+
+def test_one_third_octave_levels_from_psd_instantiation():
+    """Test OneThirdOctaveLevelsFromPSD instantiation."""
+    level_obj = OneThirdOctaveLevelsFromPSD()
+    assert level_obj.psd == None
+    assert level_obj.use_ansi_s1_11_1986 == False
+    assert level_obj.reference_value == 1.0
+    assert level_obj.frequency_weighting == ""
+
+
+def test_one_third_octave_levels_from_psd_properties():
+    """Test OneThirdOctaveLevelsFromPSD properties."""
+    level_obj = OneThirdOctaveLevelsFromPSD()
+    level_obj.psd = Field()
+    assert type(level_obj.psd) == Field
+
+    level_obj.use_ansi_s1_11_1986 = True
+    assert level_obj.use_ansi_s1_11_1986 == True
+
+    level_obj.reference_value = 2e-5
+    assert level_obj.reference_value == 2e-5
+
+    level_obj.frequency_weighting = "A"
+    assert level_obj.frequency_weighting == "A"
+
+
+def test_one_third_octave_levels_from_psd_properties_exceptions():
+    """Test OneThirdOctaveLevelsFromPSD properties exceptions."""
+    level_obj = OneThirdOctaveLevelsFromPSD()
+    with pytest.raises(PyAnsysSoundException, match="The PSD must be provided as a DPF field."):
+        level_obj.psd = "InvalidType"
+
+    with pytest.raises(
+        PyAnsysSoundException, match="The reference value must be strictly positive."
+    ):
+        level_obj.reference_value = -1
+
+    with pytest.raises(
+        PyAnsysSoundException,
+        match="The frequency weighting must be one of \\['', 'A', 'B', 'C'\\].",
+    ):
+        level_obj.frequency_weighting = "Invalid"
+
+
+def test_one_third_octave_levels_from_psd___str__(create_psd_from_txt_data):
+    """Test OneThirdOctaveLevelsFromPSD __str__ method."""
+    level_obj = OneThirdOctaveLevelsFromPSD()
+    assert str(level_obj) == EXP_STR_NOT_SET
+
+    psd = create_psd_from_txt_data
+    psd.name = "Name of the PSD"
+
+    level_obj.psd = psd
+    level_obj.use_ansi_s1_11_1986 = True
+    level_obj.reference_value = 2e-5
+    level_obj.frequency_weighting = "A"
+    assert str(level_obj) == EXP_STR_ALL_SET
+
+    level_obj.process()
+    assert str(level_obj) == EXP_STR_ALL_PROCESSED
+
+
+def test_one_third_octave_levels_from_psd_process(create_psd_from_txt_data):
+    """Test OneThirdOctaveLevelsFromPSD process method."""
+    level_obj = OneThirdOctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    level_obj.process()
+    assert level_obj._output is not None
+
+
+def test_one_third_octave_levels_from_psd_process_exceptions():
+    """Test OneThirdOctaveLevelsFromPSD process method exceptions."""
+    level_obj = OneThirdOctaveLevelsFromPSD()
+    with pytest.raises(
+        PyAnsysSoundException,
+        match="No input PSD is set. Use OneThirdOctaveLevelsFromPSD.psd.",
+    ):
+        level_obj.process()
+
+
+def test_one_third_octave_levels_from_psd_get_output(create_psd_from_txt_data):
+    """Test OneThirdOctaveLevelsFromPSD get_output method."""
+    level_obj = OneThirdOctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    level_obj.process()
+    output = level_obj.get_output()
+    assert isinstance(output, Field)
+
+
+def test_one_third_octave_levels_from_psd_get_output_warnings():
+    """Test OneThirdOctaveLevelsFromPSD get_output method warnings."""
+    level_obj = OneThirdOctaveLevelsFromPSD()
+    with pytest.warns(
+        PyAnsysSoundWarning,
+        match=(
+            "Output is not processed yet. Use the OneThirdOctaveLevelsFromPSD.process\\(\\) method."
+        ),
+    ):
+        output = level_obj.get_output()
+    assert output is None
+
+
+def test_one_third_octave_levels_from_psd_get_output_as_nparray(create_psd_from_txt_data):
+    """Test OneThirdOctaveLevelsFromPSD get_output_as_nparray method."""
+    level_obj = OneThirdOctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    with pytest.warns(
+        PyAnsysSoundWarning,
+        match=(
+            "Output is not processed yet. Use the OneThirdOctaveLevelsFromPSD.process\\(\\) method."
+        ),
+    ):
+        levels, frequencies = level_obj.get_output_as_nparray()
+    assert isinstance(levels, np.ndarray)
+    assert len(levels) == 0
+    assert isinstance(frequencies, np.ndarray)
+    assert len(frequencies) == 0
+
+    level_obj.process()
+    levels, frequencies = level_obj.get_output_as_nparray()
+    assert isinstance(levels, np.ndarray)
+    assert len(levels) == EXP_BAND_COUNT
+    assert isinstance(frequencies, np.ndarray)
+    assert len(frequencies) == EXP_BAND_COUNT
+
+
+def test_one_third_octave_levels_from_psd_get_one_third_octave_levels(create_psd_from_txt_data):
+    """Test OneThirdOctaveLevelsFromPSD get_one_third_octave_levels method."""
+    level_obj = OneThirdOctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    level_obj.process()
+    levels = level_obj.get_one_third_octave_levels()
+    assert isinstance(levels, np.ndarray)
+    assert len(levels) == EXP_BAND_COUNT
+    assert levels[16] == pytest.approx(EXP_LEVEL_DEFAULT_16)
+    assert levels[15] == pytest.approx(EXP_LEVEL_DEFAULT_15)
+    assert levels[17] == pytest.approx(EXP_LEVEL_DEFAULT_17)
+    assert levels[9] == pytest.approx(EXP_LEVEL_DEFAULT_9)
+    assert levels[21] == pytest.approx(EXP_LEVEL_DEFAULT_21)
+
+    level_obj.use_ansi_s1_11_1986 = True
+    level_obj.frequency_weighting = "A"
+    level_obj.reference_value = 2e-5
+    level_obj.process()
+
+    levels = level_obj.get_one_third_octave_levels()
+    assert levels[16] == pytest.approx(EXP_LEVEL_ANSI_A_PA_16)
+    assert levels[15] == pytest.approx(EXP_LEVEL_ANSI_A_PA_15)
+    assert levels[17] == pytest.approx(EXP_LEVEL_ANSI_A_PA_17)
+    assert levels[9] == pytest.approx(EXP_LEVEL_ANSI_A_PA_9)
+    assert levels[21] == pytest.approx(EXP_LEVEL_ANSI_A_PA_21)
+
+    level_obj.frequency_weighting = "B"
+    level_obj.process()
+
+    levels = level_obj.get_one_third_octave_levels()
+    assert levels[16] == pytest.approx(EXP_LEVEL_ANSI_B_PA_16)
+    assert levels[15] == pytest.approx(EXP_LEVEL_ANSI_B_PA_15)
+    assert levels[17] == pytest.approx(EXP_LEVEL_ANSI_B_PA_17)
+    assert levels[9] == pytest.approx(EXP_LEVEL_ANSI_B_PA_9)
+    assert levels[21] == pytest.approx(EXP_LEVEL_ANSI_B_PA_21)
+
+    level_obj.frequency_weighting = "C"
+    level_obj.process()
+
+    levels = level_obj.get_one_third_octave_levels()
+    assert levels[16] == pytest.approx(EXP_LEVEL_ANSI_C_PA_16)
+    assert levels[15] == pytest.approx(EXP_LEVEL_ANSI_C_PA_15)
+    assert levels[17] == pytest.approx(EXP_LEVEL_ANSI_C_PA_17)
+    assert levels[9] == pytest.approx(EXP_LEVEL_ANSI_C_PA_9)
+    assert levels[21] == pytest.approx(EXP_LEVEL_ANSI_C_PA_21)
+
+
+def test_one_third_octave_levels_from_psd_get_frequencies(create_psd_from_txt_data):
+    """Test OneThirdOctaveLevelsFromPSD get_frequencies method."""
+    level_obj = OneThirdOctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    level_obj.process()
+    frequencies = level_obj.get_center_frequencies()
+    assert isinstance(frequencies, np.ndarray)
+    assert len(frequencies) == EXP_BAND_COUNT
+    assert frequencies[16] == pytest.approx(EXP_FREQUENCY_16)
+    assert frequencies[15] == pytest.approx(EXP_FREQUENCY_15)
+    assert frequencies[17] == pytest.approx(EXP_FREQUENCY_17)
+    assert frequencies[9] == pytest.approx(EXP_FREQUENCY_9)
+    assert frequencies[21] == pytest.approx(EXP_FREQUENCY_21)
+
+
+@patch("matplotlib.pyplot.show")
+def test_one_third_octave_levels_from_psd_plot(mock_show, create_psd_from_txt_data):
+    """Test OneThirdOctaveLevelsFromPSD plot method."""
+    level_obj = OneThirdOctaveLevelsFromPSD(psd=create_psd_from_txt_data)
+    level_obj.process()
+    level_obj.plot()
+
+    level_obj.use_ansi_s1_11_1986 = True
+    level_obj.frequency_weighting = "A"
+    level_obj.reference_value = 2e-5
+    level_obj.process()
+    level_obj.plot()

--- a/tests/tests_standard_levels/test_standard_levels_overall_level.py
+++ b/tests/tests_standard_levels/test_standard_levels_overall_level.py
@@ -33,12 +33,12 @@ EXP_STR_NOT_SET = (
     "\tFrequency weighting: None\nOutput level value: Not processed"
 )
 EXP_STR_ALL_SET = (
-    'OverallLevel object.\nData\n\tSignal: "flute"\n\tScale type: dB\n\tReference value: 1.0\n'
+    'OverallLevel object.\nData\n\tSignal: "flute"\n\tScale type: RMS\n\tReference value: 1.0\n'
     "\tFrequency weighting: None\nOutput level value: Not processed"
 )
 EXP_STR_ALL_PROCESSED = (
-    'OverallLevel object.\nData\n\tSignal: "flute"\n\tScale type: dB\n\tReference value: 1.0\n'
-    "\tFrequency weighting: None\nOutput level value: -5.8 dB (re 1.0)"
+    'OverallLevel object.\nData\n\tSignal: "flute"\n\tScale type: dB\n\tReference value: 2e-05\n'
+    "\tFrequency weighting: A\nOutput level value: 86.7 dBA (re 2e-05)"
 )
 EXP_LEVEL_DEFAULT = -5.76525
 EXP_LEVEL_RMS = 0.514917
@@ -104,8 +104,12 @@ def test_overall_level___str__():
     f_signal = loader.get_output()[0]
 
     level_obj.signal = f_signal
+    level_obj.scale = "RMS"
     assert str(level_obj) == EXP_STR_ALL_SET
 
+    level_obj.scale = "dB"
+    level_obj.reference_value = 2e-5
+    level_obj.frequency_weighting = "A"
     level_obj.process()
     assert str(level_obj) == EXP_STR_ALL_PROCESSED
 

--- a/tests/tests_standard_levels/test_standard_levels_overall_level.py
+++ b/tests/tests_standard_levels/test_standard_levels_overall_level.py
@@ -38,7 +38,7 @@ EXP_STR_ALL_SET = (
 )
 EXP_STR_ALL_PROCESSED = (
     'OverallLevel object.\nData\n\tSignal: "flute"\n\tScale type: dB\n\tReference value: 1.0\n'
-    "\tFrequency weighting: None\nOutput level value: -5.8"
+    "\tFrequency weighting: None\nOutput level value: -5.8 dB (re 1.0)"
 )
 EXP_LEVEL_DEFAULT = -5.76525
 EXP_LEVEL_RMS = 0.514917
@@ -97,22 +97,14 @@ def test_overall_level_properties_exceptions():
 def test_overall_level___str__():
     """Test OverallLevel __str__ method."""
     level_obj = OverallLevel()
-    with pytest.warns(
-        PyAnsysSoundWarning,
-        match="Output is not processed yet. Use the OverallLevel.process\\(\\) method.",
-    ):
-        assert str(level_obj) == EXP_STR_NOT_SET
+    assert str(level_obj) == EXP_STR_NOT_SET
 
     loader = LoadWav(pytest.data_path_flute_nonUnitaryCalib_in_container)
     loader.process()
     f_signal = loader.get_output()[0]
 
     level_obj.signal = f_signal
-    with pytest.warns(
-        PyAnsysSoundWarning,
-        match="Output is not processed yet. Use the OverallLevel.process\\(\\) method.",
-    ):
-        assert str(level_obj) == EXP_STR_ALL_SET
+    assert str(level_obj) == EXP_STR_ALL_SET
 
     level_obj.process()
     assert str(level_obj) == EXP_STR_ALL_PROCESSED


### PR DESCRIPTION
Created helper classes `OctaveLevelsFromPSD` and `OneThirdOctaveLevelsFromPSD`
Added corresponding test classes
<img width="642" height="554" alt="image" src="https://github.com/user-attachments/assets/a0677613-5fb1-4ad2-8d89-69c6ca64b05d" />

Also:
- Improved unit management in classes `OverallLevel` and `LevelOverTime` and add consistency throughout the module `standard_levels`
- Remove unprocessed warning when calling __str__ in `OverallLevel` and `LevelOverTime`
- A couple of doc corrections in `TonalityECMA418_2`