### PR TITLE
fix: ``ansys-dpf-core`` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "ansys-dpf-core==0.13.8",
+    "ansys-dpf-core>=0.13.8,<1",
     "matplotlib>=3.8.2,<4",
     "platformdirs>=3.6.0",
     "requests>=2.30.0",


### PR DESCRIPTION
``ansys-dpf-core`` just released ``0.14.1`` and needs to be added to the PyAnsys metapackage.

Version control ``==`` is too restrictive and is blocking the metapackage release as ``0.13.8`` != ``0.14.1``.
Modifying it to ``"ansys-dpf-core>=0.13.8,<1"`` will fix this issue.

In order to know with which version of pydpf the ``ansys-sound-core`` package had been tested, you can add it in the optional dependencies ``tests`` and ``doc``.

----
A patch release needs to be done after pushing this PR to ``release/0.2`` as soon as possible.