### PR TITLE
Include 26.1-pre0 in the list of existing DPF Sound versions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -19,7 +19,7 @@ env:
   PACKAGE_NAME: 'ansys-sound-core'
   DOCUMENTATION_CNAME: 'sound.docs.pyansys.com'
   DOCUMENTATION_DPF_SOUND_TAG: 'latest' # DPF Sound image tag for doc building
-  TEST_DPF_SOUND_MATRIX: '["25.2", "latest"]' # List of DPF Sound image tags for testing (quotes and double quotes are important!!)
+  TEST_DPF_SOUND_MATRIX: '["25.2", "26.1-pre0", "latest"]' # List of DPF Sound image tags for testing (quotes and double quotes are important!!)
   ANSRV_DPF_SOUND_REPO: ghcr.io/ansys/ansys-sound # Docker repository for DPF Sound
   ANSRV_DPF_SOUND_PORT: 6780 # Port for DPF Sound Docker containers
   DPF_SOUND_CONT_NAME: ansys-sound-core

--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -26,5 +26,5 @@ jobs:
       with:
         package-name: 'ansys-sound'
         token: ${{ secrets.GITHUB_TOKEN }}
-        tags-kept: '25.2, latest'
+        tags-kept: '25.2, 26.1-pre0, latest'
         allow-last-days: '15'

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -72,7 +72,8 @@ By default, a DPF server is started from the latest installed Ansys version.
      - 0.1.0 and later
    * - 10.0 (Ansys 2025 R2 pre0)
      - 0.2.0 and later
-
+   * - 11.0 (Ansys 2026 R1 pre0)
+     - 0.3.0 and later
 
 Examples
 --------


### PR DESCRIPTION
26.1-pre0 is added in the list of docker images to test vs, and in the list of docker images to keep.
11.0 (equivalent to 26.1-pre0) is listed in the compatibility table of the getting started page