### PR TITLE
feat: Convert method class `PyAnsysSound`'s method `convert_fields_container_to_np_array` into a utility function in the same module

### DIFF
--- a/src/ansys/sound/core/_pyansys_sound.py
+++ b/src/ansys/sound/core/_pyansys_sound.py
@@ -23,6 +23,7 @@
 """PyAnsys Sound interface."""
 import warnings
 
+from ansys.dpf.core import FieldsContainer
 import numpy as np
 
 from ansys.sound.core.server_helpers._check_server_version import _check_dpf_version
@@ -137,33 +138,6 @@ class PyAnsysSound:
         warnings.warn(PyAnsysSoundWarning("There is nothing to output."))
         return np.empty(0)
 
-    def convert_fields_container_to_np_array(self, fc) -> np.ndarray:
-        """Convert a DPF fields container to a NumPy array.
-
-        This method converts a DPF fields container that contains several signals into a
-        NumPy array.
-
-        Parameters
-        ----------
-        fc : FieldsContainer
-            DPF fields container to convert into a NumPy array.
-
-        Returns
-        -------
-        numpy.ndarray
-            DPF fields container in a NumPy array.
-            Data in each field of the fields container is converted to a NumPy array and vertically
-            stacked into another NumPy array.
-        """
-        num_channels = len(fc)
-        np_array = np.array(fc[0].data)
-
-        if num_channels > 1:
-            for i in range(1, num_channels):
-                np_array = np.vstack((np_array, fc[i].data))
-
-        return np_array
-
 
 class PyAnsysSoundException(Exception):
     """Provides the PyAnsys Sound exception."""
@@ -179,3 +153,37 @@ class PyAnsysSoundWarning(Warning):
     def __init__(self, *args: object) -> None:
         """Init method."""
         super().__init__(*args)
+
+
+def convert_fields_container_to_np_array(fields_container: FieldsContainer) -> np.ndarray:
+    """Convert a DPF fields container to a NumPy array.
+
+    This method converts a DPF fields container that contains several signals into a
+    NumPy array.
+
+    Parameters
+    ----------
+    fc : FieldsContainer
+        DPF fields container to convert into a NumPy array.
+
+    Returns
+    -------
+    numpy.ndarray
+        DPF fields container in a NumPy array.
+        Data in each field of the fields container is converted to a NumPy array and vertically
+        stacked into another NumPy array.
+    """
+    if not isinstance(fields_container, FieldsContainer):
+        raise PyAnsysSoundException("Input must be a DPF fields container.")
+
+    num_channels = len(fields_container)
+    if num_channels == 0:
+        return np.empty(0)
+
+    np_array = np.array(fields_container[0].data)
+
+    if num_channels > 1:
+        for i in range(1, num_channels):
+            np_array = np.vstack((np_array, fields_container[i].data))
+
+    return np_array

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_2.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_2.py
@@ -28,7 +28,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from . import FIELD_DIFFUSE, FIELD_FREE, PsychoacousticsParent
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 # Name of the DPF Sound operator used in this module.
 ID_COMPUTE_LOUDNESS_ISO_532_2 = "compute_loudness_iso532_2"
@@ -266,7 +270,7 @@ class LoudnessISO532_2(PsychoacousticsParent):
             np.array(output[2]),
             np.array(output[3]),
             np.array(output[4].data),
-            self.convert_fields_container_to_np_array(output[5]),
+            convert_fields_container_to_np_array(output[5]),
             np.array(output[4].time_freq_support.time_frequencies.data),
         )
 

--- a/src/ansys/sound/core/psychoacoustics/prominence_ratio_for_orders_over_time.py
+++ b/src/ansys/sound/core/psychoacoustics/prominence_ratio_for_orders_over_time.py
@@ -28,7 +28,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from . import PsychoacousticsParent
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 # Name of the DPF Sound operator used in this module.
 ID_COMPUTE_PR_FOR_ORDERS_OVER_TIME = "compute_prominence_ratio_for_orders_over_time"
@@ -191,7 +195,7 @@ class ProminenceRatioForOrdersOverTime(PsychoacousticsParent):
             return (np.array([]), np.array([]), np.array([]))
 
         return (
-            self.convert_fields_container_to_np_array(pr_container[0]),
+            convert_fields_container_to_np_array(pr_container[0]),
             np.array(pr_container[0][0].time_freq_support.time_frequencies.data),
             np.array(pr_container[1].data),
         )

--- a/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio_for_orders_over_time.py
+++ b/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio_for_orders_over_time.py
@@ -28,7 +28,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from . import PsychoacousticsParent
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 
 class ToneToNoiseRatioForOrdersOverTime(PsychoacousticsParent):
@@ -188,7 +192,7 @@ class ToneToNoiseRatioForOrdersOverTime(PsychoacousticsParent):
             return (np.array([]), np.array([]), np.array([]))
 
         return (
-            self.convert_fields_container_to_np_array(tnr_container[0]),
+            convert_fields_container_to_np_array(tnr_container[0]),
             np.array(tnr_container[0][0].time_freq_support.time_frequencies.data),
             np.array(tnr_container[1].data),
         )

--- a/src/ansys/sound/core/signal_utilities/apply_gain.py
+++ b/src/ansys/sound/core/signal_utilities/apply_gain.py
@@ -28,7 +28,11 @@ from ansys.dpf.core import Field, FieldsContainer, Operator
 import numpy as np
 
 from . import SignalUtilitiesParent
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 
 class ApplyGain(SignalUtilitiesParent):
@@ -148,4 +152,4 @@ class ApplyGain(SignalUtilitiesParent):
         if type(output) == Field:
             return output.data
 
-        return self.convert_fields_container_to_np_array(output)
+        return convert_fields_container_to_np_array(output)

--- a/src/ansys/sound/core/signal_utilities/crop_signal.py
+++ b/src/ansys/sound/core/signal_utilities/crop_signal.py
@@ -27,7 +27,11 @@ from ansys.dpf.core import Field, FieldsContainer, Operator
 import numpy as np
 
 from . import SignalUtilitiesParent
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 
 class CropSignal(SignalUtilitiesParent):
@@ -147,4 +151,4 @@ class CropSignal(SignalUtilitiesParent):
         if type(output) == Field:
             return output.data
 
-        return self.convert_fields_container_to_np_array(output)
+        return convert_fields_container_to_np_array(output)

--- a/src/ansys/sound/core/signal_utilities/load_wav.py
+++ b/src/ansys/sound/core/signal_utilities/load_wav.py
@@ -28,7 +28,11 @@ from ansys.dpf.core import DataSources, FieldsContainer, Operator
 import numpy as np
 
 from . import SignalUtilitiesParent
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 
 class LoadWav(SignalUtilitiesParent):
@@ -111,4 +115,4 @@ class LoadWav(SignalUtilitiesParent):
         """
         fc = self.get_output()
 
-        return self.convert_fields_container_to_np_array(fc)
+        return convert_fields_container_to_np_array(fc)

--- a/src/ansys/sound/core/signal_utilities/resample.py
+++ b/src/ansys/sound/core/signal_utilities/resample.py
@@ -28,7 +28,11 @@ from ansys.dpf.core import Field, FieldsContainer, Operator
 import numpy as np
 
 from . import SignalUtilitiesParent
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 
 class Resample(SignalUtilitiesParent):
@@ -128,4 +132,4 @@ class Resample(SignalUtilitiesParent):
         if type(output) == Field:
             return output.data
 
-        return self.convert_fields_container_to_np_array(output)
+        return convert_fields_container_to_np_array(output)

--- a/src/ansys/sound/core/signal_utilities/zero_pad.py
+++ b/src/ansys/sound/core/signal_utilities/zero_pad.py
@@ -27,7 +27,11 @@ from ansys.dpf.core import Field, FieldsContainer, Operator
 import numpy as np
 
 from . import SignalUtilitiesParent
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 
 class ZeroPad(SignalUtilitiesParent):
@@ -127,4 +131,4 @@ class ZeroPad(SignalUtilitiesParent):
         if type(output) == Field:
             return output.data
 
-        return self.convert_fields_container_to_np_array(output)
+        return convert_fields_container_to_np_array(output)

--- a/src/ansys/sound/core/spectrogram_processing/isolate_orders.py
+++ b/src/ansys/sound/core/spectrogram_processing/isolate_orders.py
@@ -29,7 +29,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from . import SpectrogramProcessingParent
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 
 class IsolateOrders(SpectrogramProcessingParent):
@@ -259,7 +263,7 @@ class IsolateOrders(SpectrogramProcessingParent):
         if type(output) == Field:
             return output.data
 
-        return self.convert_fields_container_to_np_array(output)
+        return convert_fields_container_to_np_array(output)
 
     def plot(self):
         """Plot the signal after order isolation."""

--- a/src/ansys/sound/core/xtract/xtract.py
+++ b/src/ansys/sound/core/xtract/xtract.py
@@ -34,7 +34,11 @@ from . import (
     XtractTonalParameters,
     XtractTransientParameters,
 )
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 
 class Xtract(XtractParent):
@@ -322,10 +326,10 @@ class Xtract(XtractParent):
                 return np.array([]), np.array([]), np.array([]), np.array([])
             else:
                 return (
-                    self.convert_fields_container_to_np_array(l_output_noise_signal),
-                    self.convert_fields_container_to_np_array(l_output_tonal_signal),
-                    self.convert_fields_container_to_np_array(l_output_transient_signal),
-                    self.convert_fields_container_to_np_array(l_output_remainder_signal),
+                    convert_fields_container_to_np_array(l_output_noise_signal),
+                    convert_fields_container_to_np_array(l_output_tonal_signal),
+                    convert_fields_container_to_np_array(l_output_transient_signal),
+                    convert_fields_container_to_np_array(l_output_remainder_signal),
                 )
 
     def plot(self):

--- a/src/ansys/sound/core/xtract/xtract_denoiser.py
+++ b/src/ansys/sound/core/xtract/xtract_denoiser.py
@@ -29,7 +29,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from . import XtractDenoiserParameters, XtractParent
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 
 class XtractDenoiser(XtractParent):
@@ -170,9 +174,9 @@ class XtractDenoiser(XtractParent):
             if self.output_denoised_signals is None or self.output_noise_signals is None:
                 return np.array([]), np.array([])
             else:
-                return self.convert_fields_container_to_np_array(
+                return convert_fields_container_to_np_array(
                     l_output_denoised_signals
-                ), self.convert_fields_container_to_np_array(l_output_noise_signals)
+                ), convert_fields_container_to_np_array(l_output_noise_signals)
 
     def plot(self):
         """Plot signals.

--- a/src/ansys/sound/core/xtract/xtract_tonal.py
+++ b/src/ansys/sound/core/xtract/xtract_tonal.py
@@ -29,7 +29,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from . import XtractParent, XtractTonalParameters
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 
 class XtractTonal(XtractParent):
@@ -179,8 +183,8 @@ class XtractTonal(XtractParent):
                 return np.array([]), np.array([])
             else:
                 return (
-                    self.convert_fields_container_to_np_array(l_output_tonal_signals),
-                    self.convert_fields_container_to_np_array(l_output_non_tonal_signals),
+                    convert_fields_container_to_np_array(l_output_tonal_signals),
+                    convert_fields_container_to_np_array(l_output_non_tonal_signals),
                 )
 
     def plot(self):

--- a/src/ansys/sound/core/xtract/xtract_transient.py
+++ b/src/ansys/sound/core/xtract/xtract_transient.py
@@ -29,7 +29,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from . import XtractParent, XtractTransientParameters
-from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from .._pyansys_sound import (
+    PyAnsysSoundException,
+    PyAnsysSoundWarning,
+    convert_fields_container_to_np_array,
+)
 
 
 class XtractTransient(XtractParent):
@@ -180,8 +184,8 @@ class XtractTransient(XtractParent):
                 return np.array([]), np.array([])
             else:
                 return (
-                    self.convert_fields_container_to_np_array(l_output_transient_signals),
-                    self.convert_fields_container_to_np_array(l_output_non_transient_signals),
+                    convert_fields_container_to_np_array(l_output_transient_signals),
+                    convert_fields_container_to_np_array(l_output_non_transient_signals),
                 )
 
     def plot(self):


### PR DESCRIPTION
Method `convert_fields_container_to_np_array` was moved out of class `PyAnsysSound` and converted to a function (within the same module `_pyansys_sound`).
Reasons for this change are:
- to simplify (and make more sensical) its use. Previously, you could end up doing weird (with `self` appearing twice), for example `self.convert_fields_container_to_np_array(self.some_fields_container_within_the_object)`. Generally the inconsistency was that this method was not applicable in all subclasses, and would not use on the object members, such that there was no point in attaching it to the class.
- so that it does not appear in every class's documentation