### PR TITLE
test: fix sharpness DIN45692 test values following minor change in DPF Sound

### DIFF
--- a/doc/changelog.d/479.maintenance.md
+++ b/doc/changelog.d/479.maintenance.md
@@ -1,1 +1,1 @@
-Maint: fix sharpness DIN45692 test values following minor change in DPF Sound
+Test: fix sharpness DIN45692 test values following minor change in DPF Sound

--- a/doc/changelog.d/479.maintenance.md
+++ b/doc/changelog.d/479.maintenance.md
@@ -1,0 +1,1 @@
+Maint: fix sharpness DIN45692 test values following minor change in DPF Sound

--- a/tests/tests_psychoacoustics/test_psychoacoustics_sharpness_din_45692.py
+++ b/tests/tests_psychoacoustics/test_psychoacoustics_sharpness_din_45692.py
@@ -28,8 +28,13 @@ from ansys.sound.core._pyansys_sound import PyAnsysSoundException, PyAnsysSoundW
 from ansys.sound.core.psychoacoustics import SharpnessDIN45692
 from ansys.sound.core.signal_utilities import LoadWav
 
-EXP_SHARPNESS_FREE = 1.212127
-EXP_SHARPNESS_DIFFUSE = 1.221791
+if pytest.SOUND_VERSION_GREATER_THAN_OR_EQUAL_TO_2027R1:
+    # Sound_mlb_lib update (see PR668614)
+    EXP_SHARPNESS_FREE = 1.212127
+    EXP_SHARPNESS_DIFFUSE = 1.221791
+else:
+    EXP_SHARPNESS_FREE = 1.212122
+    EXP_SHARPNESS_DIFFUSE = 1.221786
 
 EXP_STR_DEFAULT = (
     "SharpnessDIN45692 object\nData:\n\tSignal name: Not set\nSharpness: Not processed"

--- a/tests/tests_psychoacoustics/test_psychoacoustics_sharpness_din_45692.py
+++ b/tests/tests_psychoacoustics/test_psychoacoustics_sharpness_din_45692.py
@@ -28,8 +28,8 @@ from ansys.sound.core._pyansys_sound import PyAnsysSoundException, PyAnsysSoundW
 from ansys.sound.core.psychoacoustics import SharpnessDIN45692
 from ansys.sound.core.signal_utilities import LoadWav
 
-EXP_SHARPNESS_FREE = 1.212122
-EXP_SHARPNESS_DIFFUSE = 1.221786
+EXP_SHARPNESS_FREE = 1.212127
+EXP_SHARPNESS_DIFFUSE = 1.221791
 
 EXP_STR_DEFAULT = (
     "SharpnessDIN45692 object\nData:\n\tSignal name: Not set\nSharpness: Not processed"


### PR DESCRIPTION
A minor computational change in DPF Sound triggered slightly different output values for DIN 45692 Sharpness values.
Test values are adjusted accordingly.
Note: the error/update is in the range 1e-5 acum, which is negligible.