### PR TITLE
ci: auto fix pre-commit update PR title

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.7.1
+  rev: v0.7.2
   hooks:
     - id: add-license-headers
       files: '(src|examples|tests|docker)/.*\.(py)|\.(proto)'
@@ -48,6 +48,6 @@ repos:
       - --start_year=2023
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.37.1
+  rev: 0.37.2
   hooks:
     - id: check-github-workflows

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+ci:
+  autofix_commit_msg: 'chore: auto fixes from pre-commit hooks'
+  autoupdate_commit_msg: 'chore: pre-commit automatic update'
+  autoupdate_schedule: weekly
+
 repos:
 
 - repo: https://github.com/psf/black-pre-commit-mirror
@@ -35,7 +40,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.7.2
+  rev: v0.7.1
   hooks:
     - id: add-license-headers
       files: '(src|examples|tests|docker)/.*\.(py)|\.(proto)'
@@ -43,6 +48,6 @@ repos:
       - --start_year=2023
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.37.2
+  rev: 0.37.1
   hooks:
     - id: check-github-workflows

--- a/doc/changelog.d/493.miscellaneous.md
+++ b/doc/changelog.d/493.miscellaneous.md
@@ -1,0 +1,1 @@
+Ci: auto fix pre-commit update PR title


### PR DESCRIPTION
Everytime pre-commit is updated, an automatic PR is created, but the PR title causes the checks to fail, because it does not start with an expected PR type specifiier.
It is quite easy to fix the title (by adding "chore:" at the start), but then a new changelog is pushed, which re-triggers _all_ checks.
We've lived with it so far as it is a quite minor annoyance, but it is an annoyance nonetheless as it keeps happening every week or so.

This PR aims at fixing this, by automatically renaming the pre-commit update PR title (mostly the `autoupdate_commit_msg` directive, the others simply replicate the default behavior that was used until now).
This change was replicated from the `pyansys-geometry` repo (https://github.com/ansys/pyansys-geometry/blob/c7e98853389cb9ee77e0bab14760f6c13f12110a/.pre-commit-config.yaml#L1-L4)