### PR TITLE
fix: unit management adjustments following unit bug fixes in package `ansys-sound`

### DIFF
--- a/doc/changelog.d/507.fixed.md
+++ b/doc/changelog.d/507.fixed.md
@@ -1,1 +1,1 @@
-Fix: unit management adjustments following unit bug fixes in package \`ansys-sound\`
+Fix: unit management adjustments following unit bug fixes in package `ansys-sound`

--- a/doc/changelog.d/507.fixed.md
+++ b/doc/changelog.d/507.fixed.md
@@ -1,1 +1,1 @@
-Fix: unit managerment adjustments following unit bug fixes in package \`ansys-sound\`
+Fix: unit management adjustments following unit bug fixes in package \`ansys-sound\`

--- a/doc/changelog.d/507.fixed.md
+++ b/doc/changelog.d/507.fixed.md
@@ -1,0 +1,1 @@
+Fix: unit managerment adjustments following unit bug fixes in package \`ansys-sound\`

--- a/doc/changelog.d/507.fixed.md
+++ b/doc/changelog.d/507.fixed.md
@@ -1,1 +1,1 @@
-Fix: unit management adjustments following unit bug fixes in package `ansys-sound`
+Fix: unit management adjustments following unit bug fixes in package \`ansys-sound\`

--- a/src/ansys/sound/core/psychoacoustics/fluctuation_strength.py
+++ b/src/ansys/sound/core/psychoacoustics/fluctuation_strength.py
@@ -219,8 +219,12 @@ class FluctuationStrength(PsychoacousticsParent):
 
         bark_band_indexes = self.get_bark_band_indexes()
         specific_fluctuation_strength = self.get_output_as_nparray()[1]
-        unit = self.get_output()[1].unit[1]
-        bark_unit = self.get_output()[1].time_freq_support.time_frequencies.unit[1]
+        unit = self.get_output()[1].unit
+        if isinstance(unit, tuple):
+            unit = unit[1]
+        bark_unit = self.get_output()[1].time_freq_support.time_frequencies.unit
+        if isinstance(bark_unit, tuple):
+            bark_unit = bark_unit[1]
 
         plt.plot(bark_band_indexes, specific_fluctuation_strength)
         plt.title("Specific fluctuation strength")

--- a/src/ansys/sound/core/psychoacoustics/fluctuation_strength.py
+++ b/src/ansys/sound/core/psychoacoustics/fluctuation_strength.py
@@ -220,10 +220,11 @@ class FluctuationStrength(PsychoacousticsParent):
         bark_band_indexes = self.get_bark_band_indexes()
         specific_fluctuation_strength = self.get_output_as_nparray()[1]
         unit = self.get_output()[1].unit[1]
+        bark_unit = self.get_output()[1].time_freq_support.time_frequencies.unit[1]
 
         plt.plot(bark_band_indexes, specific_fluctuation_strength)
         plt.title("Specific fluctuation strength")
-        plt.xlabel(f"Bark band index")
+        plt.xlabel(f"z ({bark_unit})")
         plt.ylabel(f"Fluctuation strength ({unit})")
         plt.grid(True)
         plt.show()

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
@@ -254,8 +254,12 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
 
         bark_band_indexes = self.get_bark_band_indexes()
         specific_loudness = self.get_specific_loudness()
-        unit = self.get_output()[2].unit[1]
-        bark_unit = self.get_output()[2].time_freq_support.time_frequencies.unit[1]
+        unit = self.get_output()[2].unit
+        if isinstance(unit, tuple):
+            unit = unit[1]
+        bark_unit = self.get_output()[2].time_freq_support.time_frequencies.unit
+        if isinstance(bark_unit, tuple):
+            bark_unit = bark_unit[1]
 
         plt.plot(bark_band_indexes, specific_loudness)
         plt.title("Specific loudness")

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_stationary.py
@@ -255,10 +255,11 @@ class LoudnessISO532_1_Stationary(PsychoacousticsParent):
         bark_band_indexes = self.get_bark_band_indexes()
         specific_loudness = self.get_specific_loudness()
         unit = self.get_output()[2].unit[1]
+        bark_unit = self.get_output()[2].time_freq_support.time_frequencies.unit[1]
 
         plt.plot(bark_band_indexes, specific_loudness)
         plt.title("Specific loudness")
-        plt.xlabel("Bark band index")
+        plt.xlabel(f"z ({bark_unit})")
         plt.ylabel(f"N' ({unit})")
         plt.grid(True)
         plt.show()

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_time_varying.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_1_time_varying.py
@@ -326,14 +326,18 @@ class LoudnessISO532_1_TimeVarying(PsychoacousticsParent):
         _, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
 
         # Plot loudness in sone
-        unit = self.get_output()[0].unit[1]
+        unit = self.get_output()[0].unit
+        if isinstance(unit, tuple):
+            unit = unit[1]
         ax1.plot(time, self.get_loudness_sone_vs_time())
         ax1.set_title("Instantaneous loudness")
         ax1.set_ylabel(f"N ({unit})")
         ax1.grid(True)
 
         # Plot loudness level in phon
-        unit = self.get_output()[3].unit[1]
+        unit = self.get_output()[3].unit
+        if isinstance(unit, tuple):
+            unit = unit[1]
         ax2.plot(time, self.get_loudness_level_phon_vs_time())
         ax2.set_title("Instantaneous loudness level")
         ax2.set_xlabel("Time (s)")

--- a/src/ansys/sound/core/psychoacoustics/loudness_iso_532_2.py
+++ b/src/ansys/sound/core/psychoacoustics/loudness_iso_532_2.py
@@ -425,7 +425,9 @@ class LoudnessISO532_2(PsychoacousticsParent):
 
         center_frequency = self.get_erb_center_frequencies()
         specific_loudness = self.get_binaural_specific_loudness()
-        unit = self.get_output()[4].unit[1]
+        unit = self.get_output()[4].unit
+        if isinstance(unit, tuple):
+            unit = unit[1]
 
         plt.plot(center_frequency, specific_loudness)
         plt.title("Binaural specific loudness")

--- a/src/ansys/sound/core/psychoacoustics/prominence_ratio_for_orders_over_time.py
+++ b/src/ansys/sound/core/psychoacoustics/prominence_ratio_for_orders_over_time.py
@@ -280,7 +280,9 @@ class ProminenceRatioForOrdersOverTime(PsychoacousticsParent):
                 f"Output is not processed yet. Use the ``{__class__.__name__}.process()`` method."
             )
 
-        pr_unit = output[0][0].unit[1]
+        pr_unit = output[0][0].unit
+        if isinstance(pr_unit, tuple):
+            pr_unit = pr_unit[1]
         time = output[0][0].time_freq_support.time_frequencies
         rpm = output[1]
 

--- a/src/ansys/sound/core/psychoacoustics/roughness.py
+++ b/src/ansys/sound/core/psychoacoustics/roughness.py
@@ -256,10 +256,7 @@ class Roughness(PsychoacousticsParent):
         specific_roughness = self.get_specific_roughness()
         roughness_over_time = self.get_roughness_over_time()
         time_scale = self.get_time_scale()
-        bark_unit = self.get_output()[1].time_freq_support.time_frequencies.unit
-        if isinstance(bark_unit, tuple):
-            bark_unit = bark_unit[1]
-        bark_unit_str = f" ({bark_unit})" if len(bark_unit) > 0 else ""
+        bark_unit = self.get_output()[1].time_freq_support.time_frequencies.unit[1]
         time_unit = self.get_output()[2].time_freq_support.time_frequencies.unit
         specific_roughness_unit = self.get_output()[1].unit[1]
         roughness_over_time_unit = self.get_output()[2].unit[1]
@@ -268,7 +265,7 @@ class Roughness(PsychoacousticsParent):
 
         axes[0].plot(bark_band_indexes, specific_roughness)
         axes[0].set_title("Specific roughness")
-        axes[0].set_xlabel(f"z{bark_unit_str}")
+        axes[0].set_xlabel(f"z ({bark_unit})")
         axes[0].set_ylabel(f"R' ({specific_roughness_unit})")
         axes[0].grid(True)
 

--- a/src/ansys/sound/core/psychoacoustics/roughness.py
+++ b/src/ansys/sound/core/psychoacoustics/roughness.py
@@ -259,6 +259,7 @@ class Roughness(PsychoacousticsParent):
         bark_unit = self.get_output()[1].time_freq_support.time_frequencies.unit
         if isinstance(bark_unit, tuple):
             bark_unit = bark_unit[1]
+        bark_unit_str = f" ({bark_unit})" if len(bark_unit) > 0 else ""
         time_unit = self.get_output()[2].time_freq_support.time_frequencies.unit
         specific_roughness_unit = self.get_output()[1].unit
         if isinstance(specific_roughness_unit, tuple):
@@ -271,7 +272,7 @@ class Roughness(PsychoacousticsParent):
 
         axes[0].plot(bark_band_indexes, specific_roughness)
         axes[0].set_title("Specific roughness")
-        axes[0].set_xlabel(f"z ({bark_unit})")
+        axes[0].set_xlabel(f"z{bark_unit_str}")
         axes[0].set_ylabel(f"R' ({specific_roughness_unit})")
         axes[0].grid(True)
 

--- a/src/ansys/sound/core/psychoacoustics/roughness.py
+++ b/src/ansys/sound/core/psychoacoustics/roughness.py
@@ -256,10 +256,16 @@ class Roughness(PsychoacousticsParent):
         specific_roughness = self.get_specific_roughness()
         roughness_over_time = self.get_roughness_over_time()
         time_scale = self.get_time_scale()
-        bark_unit = self.get_output()[1].time_freq_support.time_frequencies.unit[1]
+        bark_unit = self.get_output()[1].time_freq_support.time_frequencies.unit
+        if isinstance(bark_unit, tuple):
+            bark_unit = bark_unit[1]
         time_unit = self.get_output()[2].time_freq_support.time_frequencies.unit
-        specific_roughness_unit = self.get_output()[1].unit[1]
-        roughness_over_time_unit = self.get_output()[2].unit[1]
+        specific_roughness_unit = self.get_output()[1].unit
+        if isinstance(specific_roughness_unit, tuple):
+            specific_roughness_unit = specific_roughness_unit[1]
+        roughness_over_time_unit = self.get_output()[2].unit
+        if isinstance(roughness_over_time_unit, tuple):
+            roughness_over_time_unit = roughness_over_time_unit[1]
 
         _, axes = plt.subplots(2, 1, sharex=False)
 

--- a/src/ansys/sound/core/psychoacoustics/sharpness_din_45692_over_time.py
+++ b/src/ansys/sound/core/psychoacoustics/sharpness_din_45692_over_time.py
@@ -230,7 +230,9 @@ class SharpnessDIN45692OverTime(PsychoacousticsParent):
 
         sharpness_over_time = self.get_sharpness_over_time()
         time_scale = self.get_time_scale()
-        sharpness_unit = self.get_output()[1].unit[1]
+        sharpness_unit = self.get_output()[1].unit
+        if isinstance(sharpness_unit, tuple):
+            sharpness_unit = sharpness_unit[1]
         time_unit = self.get_output()[1].time_freq_support.time_frequencies.unit
 
         plt.figure()

--- a/src/ansys/sound/core/psychoacoustics/sharpness_over_time.py
+++ b/src/ansys/sound/core/psychoacoustics/sharpness_over_time.py
@@ -227,7 +227,9 @@ class SharpnessOverTime(PsychoacousticsParent):
 
         sharpness_over_time = self.get_sharpness_over_time()
         time_scale = self.get_time_scale()
-        sharpness_unit = self.get_output()[1].unit[1]
+        sharpness_unit = self.get_output()[1].unit
+        if isinstance(sharpness_unit, tuple):
+            sharpness_unit = sharpness_unit[1]
         time_unit = self.get_output()[1].time_freq_support.time_frequencies.unit
 
         plt.figure()

--- a/src/ansys/sound/core/psychoacoustics/tonality_aures.py
+++ b/src/ansys/sound/core/psychoacoustics/tonality_aures.py
@@ -330,7 +330,9 @@ class TonalityAures(PsychoacousticsParent):
         wT = self.get_tonal_weighting_over_time()
         wGr = self.get_loudness_weighting_over_time()
         time_scale = self.get_time_scale()
-        tonality_unit = self.get_output()[1].unit[1]
+        tonality_unit = self.get_output()[1].unit
+        if isinstance(tonality_unit, tuple):
+            tonality_unit = tonality_unit[1]
         time_unit = self.get_output()[1].time_freq_support.time_frequencies.unit
 
         _, axes = plt.subplots(3, 1, sharex=True)

--- a/src/ansys/sound/core/psychoacoustics/tonality_din_45681.py
+++ b/src/ansys/sound/core/psychoacoustics/tonality_din_45681.py
@@ -472,8 +472,12 @@ class TonalityDIN45681(PsychoacousticsParent):
         decisive_frequency_over_time = self.get_decisive_frequency_over_time()
         tonal_adjustment_over_time = self.get_tonal_adjustment_over_time()
         time_scale = self.get_time_scale()
-        difference_unit = self.get_output()[3].unit[1]
-        adjustment_unit = self.get_output()[6].unit[1]
+        difference_unit = self.get_output()[3].unit
+        if isinstance(difference_unit, tuple):
+            difference_unit = difference_unit[1]
+        adjustment_unit = self.get_output()[6].unit
+        if isinstance(adjustment_unit, tuple):
+            adjustment_unit = adjustment_unit[1]
         frequency_unit = self.get_output()[5].unit
         time_unit = self.get_output()[3].time_freq_support.time_frequencies.unit
 

--- a/src/ansys/sound/core/psychoacoustics/tonality_ecma_418_2.py
+++ b/src/ansys/sound/core/psychoacoustics/tonality_ecma_418_2.py
@@ -350,7 +350,9 @@ class TonalityECMA418_2(PsychoacousticsParent):
         ft_over_time = self.get_tone_frequency_over_time()
         time_scale_tonality = self.get_tonality_time_scale()
         time_scale_ft = self.get_tone_frequency_time_scale()
-        tonality_unit = self.get_output()[1].unit[1]
+        tonality_unit = self.get_output()[1].unit
+        if isinstance(tonality_unit, tuple):
+            tonality_unit = tonality_unit[1]
         time_unit = self.get_output()[1].time_freq_support.time_frequencies.unit
         frequency_unit = self.get_output()[2].unit
 

--- a/src/ansys/sound/core/psychoacoustics/tonality_iso_1996_2_over_time.py
+++ b/src/ansys/sound/core/psychoacoustics/tonality_iso_1996_2_over_time.py
@@ -403,8 +403,12 @@ class TonalityISO1996_2_OverTime(PsychoacousticsParent):
         tonal_audibility = self.get_tonal_audibility_over_time()
         tonal_adjustment = self.get_tonal_adjustment_over_time()
         time_scale = self.get_time_scale()
-        tonal_audibility_unit = self.get_output()[0].unit[1]
-        tonal_adjustment_unit = self.get_output()[1].unit[1]
+        tonal_audibility_unit = self.get_output()[0].unit
+        if isinstance(tonal_audibility_unit, tuple):
+            tonal_audibility_unit = tonal_audibility_unit[1]
+        tonal_adjustment_unit = self.get_output()[1].unit
+        if isinstance(tonal_adjustment_unit, tuple):
+            tonal_adjustment_unit = tonal_adjustment_unit[1]
         time_unit = self.get_output()[0].time_freq_support.time_frequencies.unit
 
         _, axes = plt.subplots(2, 1, sharex=True)

--- a/src/ansys/sound/core/psychoacoustics/tonality_iso_ts_20065.py
+++ b/src/ansys/sound/core/psychoacoustics/tonality_iso_ts_20065.py
@@ -436,7 +436,9 @@ class TonalityISOTS20065(PsychoacousticsParent):
         decisive_audibility_over_time = self.get_decisive_audibility_over_time()
         decisive_frequency_over_time = self.get_decisive_frequency_over_time()
         time_scale = self.get_time_scale()
-        difference_unit = self.get_output()[2].unit[1]
+        difference_unit = self.get_output()[2].unit
+        if isinstance(difference_unit, tuple):
+            difference_unit = difference_unit[1]
         frequency_unit = self.get_output()[4].unit
         time_unit = self.get_output()[2].time_freq_support.time_frequencies.unit
 

--- a/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio_for_orders_over_time.py
+++ b/src/ansys/sound/core/psychoacoustics/tone_to_noise_ratio_for_orders_over_time.py
@@ -277,7 +277,9 @@ class ToneToNoiseRatioForOrdersOverTime(PsychoacousticsParent):
                 f"Output is not processed yet. Use the ``{__class__.__name__}.process()`` method."
             )
 
-        tnr_unit = output[0][0].unit[1]
+        tnr_unit = output[0][0].unit
+        if isinstance(tnr_unit, tuple):
+            tnr_unit = tnr_unit[1]
         time = output[0][0].time_freq_support.time_frequencies
         rpm = output[1]
 

--- a/src/ansys/sound/core/sound_composer/source_control_time.py
+++ b/src/ansys/sound/core/sound_composer/source_control_time.py
@@ -22,12 +22,14 @@
 
 """Sound Composer's source control over time."""
 
+import warnings
+
 from ansys.dpf.core import Field, Operator
 from matplotlib import pyplot as plt
 
 from ansys.sound.core.signal_utilities.load_wav import LoadWav
 
-from .._pyansys_sound import PyAnsysSoundException
+from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
 from ._source_control_parent import SourceControlParent
 
 ID_LOAD_FROM_TEXT = "load_sound_samples_from_txt"
@@ -57,7 +59,7 @@ class SourceControlTime(SourceControlParent):
             Example demonstrating how to create a Sound Composer project from scratch.
     """
 
-    def __init__(self, file_str: str = ""):
+    def __init__(self, file_str: str = "", expected_unit: str = ""):
         """Class instantiation takes the following parameters.
 
         Parameters
@@ -65,6 +67,9 @@ class SourceControlTime(SourceControlParent):
         file_str : str, default: ""
             Path to the control data file. Supported files are WAV files and and text files with
             the header `AnsysSound_SoundSamples`.
+        expected_unit : str, default: ""
+            Expected unit of the control data when loading from a text file. Ignored when loading
+            from a WAV file.
         """
         super().__init__()
 
@@ -73,9 +78,15 @@ class SourceControlTime(SourceControlParent):
 
         if len(file_str) > 0:
             if file_str.endswith(".wav"):
+                if len(expected_unit) > 0:
+                    warnings.warn(
+                        PyAnsysSoundWarning(
+                            "Expected unit is ignored when loading control data from a WAV file."
+                        )
+                    )
                 self.load_from_wave_file(file_str)
             else:
-                self.load_from_text_file(file_str)
+                self.load_from_text_file(file_str, expected_unit)
         else:
             self.control = None
 
@@ -146,7 +157,7 @@ class SourceControlTime(SourceControlParent):
         loader.process()
         self.control = loader.get_output()[0]
 
-    def load_from_text_file(self, file_str: str):
+    def load_from_text_file(self, file_str: str, expected_unit: str = ""):
         """Load control data from a text file.
 
         Parameters
@@ -154,18 +165,19 @@ class SourceControlTime(SourceControlParent):
         file_str : str
             Path to the text file. Supported files have the same text format (with the header
             `AnsysSound_SoundSamples`) as supported by Ansys Sound SAS.
+        expected_unit : str, default: ""
+            Expected unit of the loaded control data.
         """
         # Set operator inputs.
         self.__operator_load.connect(0, file_str)
+        if len(expected_unit) > 0:
+            self.__operator_load.connect(1, expected_unit)
 
         # Run the operator.
         self.__operator_load.run()
 
         # Get the loaded sound power level parameters.
         self.control = self.__operator_load.get_output(0, "field")
-
-        # Clear the control unit, as this operator always returns the unit as "Pa".
-        self.control.unit = ""
 
     def plot(self):
         """Plot the control profile."""

--- a/src/ansys/sound/core/sound_power/sound_power_level_iso_3744.py
+++ b/src/ansys/sound/core/sound_power/sound_power_level_iso_3744.py
@@ -579,22 +579,18 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         # Display octave-band levels in the upper subplot.
         Lw = self.get_Lw_octave()
-        Lw_unit = self.get_output()[2].unit
-        Lw_unit = Lw_unit if isinstance(Lw_unit, str) else Lw_unit[1]
-        Lw_unit_str = f" ({Lw_unit})" if len(Lw_unit) > 0 else ""
+        Lw_unit = self.get_output()[2].unit[1]
         f_center = self.get_octave_center_frequencies()
 
         plt.subplot(211)
         plt.bar(range(len(Lw)), Lw)
         plt.xticks(range(len(Lw)), f_center.astype(int), rotation=45, fontsize=9)
         plt.title("Octave-band sound power level")
-        plt.ylabel(r"$\mathregular{L_w}$" + Lw_unit_str)
+        plt.ylabel(r"$\mathregular{L_w}$" + f" ({Lw_unit})")
 
         # Display 1/3-octave-band levels in the lower subplot.
         Lw = self.get_Lw_thirdoctave()
-        Lw_unit = self.get_output()[3].unit
-        Lw_unit = Lw_unit if isinstance(Lw_unit, str) else Lw_unit[1]
-        Lw_unit_str = f" ({Lw_unit})" if len(Lw_unit) > 0 else ""
+        Lw_unit = self.get_output()[3].unit[1]
         f_center = self.get_thirdoctave_center_frequencies()
         f_unit = self.get_output()[3].time_freq_support.time_frequencies.unit
 
@@ -602,7 +598,7 @@ class SoundPowerLevelISO3744(SoundPowerParent):
         plt.bar(range(len(Lw)), Lw)
         plt.xticks(range(len(Lw)), f_center.astype(int), rotation=45, fontsize=9)
         plt.title("1/3-octave-band sound power level")
-        plt.ylabel(r"$\mathregular{L_w}$" + Lw_unit_str)
+        plt.ylabel(r"$\mathregular{L_w}$" + f" ({Lw_unit})")
         plt.xlabel(f"Frequency ({f_unit})")
 
         plt.tight_layout()

--- a/src/ansys/sound/core/sound_power/sound_power_level_iso_3744.py
+++ b/src/ansys/sound/core/sound_power/sound_power_level_iso_3744.py
@@ -579,18 +579,22 @@ class SoundPowerLevelISO3744(SoundPowerParent):
 
         # Display octave-band levels in the upper subplot.
         Lw = self.get_Lw_octave()
-        Lw_unit = self.get_output()[2].unit[1]
+        Lw_unit = self.get_output()[2].unit
+        Lw_unit = Lw_unit if isinstance(Lw_unit, str) else Lw_unit[1]
+        Lw_unit_str = f" ({Lw_unit})" if len(Lw_unit) > 0 else ""
         f_center = self.get_octave_center_frequencies()
 
         plt.subplot(211)
         plt.bar(range(len(Lw)), Lw)
         plt.xticks(range(len(Lw)), f_center.astype(int), rotation=45, fontsize=9)
         plt.title("Octave-band sound power level")
-        plt.ylabel(r"$\mathregular{L_w}$" + f" ({Lw_unit})")
+        plt.ylabel(r"$\mathregular{L_w}$" + Lw_unit_str)
 
         # Display 1/3-octave-band levels in the lower subplot.
         Lw = self.get_Lw_thirdoctave()
-        Lw_unit = self.get_output()[3].unit[1]
+        Lw_unit = self.get_output()[3].unit
+        Lw_unit = Lw_unit if isinstance(Lw_unit, str) else Lw_unit[1]
+        Lw_unit_str = f" ({Lw_unit})" if len(Lw_unit) > 0 else ""
         f_center = self.get_thirdoctave_center_frequencies()
         f_unit = self.get_output()[3].time_freq_support.time_frequencies.unit
 
@@ -598,7 +602,7 @@ class SoundPowerLevelISO3744(SoundPowerParent):
         plt.bar(range(len(Lw)), Lw)
         plt.xticks(range(len(Lw)), f_center.astype(int), rotation=45, fontsize=9)
         plt.title("1/3-octave-band sound power level")
-        plt.ylabel(r"$\mathregular{L_w}$" + f" ({Lw_unit})")
+        plt.ylabel(r"$\mathregular{L_w}$" + Lw_unit_str)
         plt.xlabel(f"Frequency ({f_unit})")
 
         plt.tight_layout()

--- a/src/ansys/sound/core/spectrogram_processing/stft.py
+++ b/src/ansys/sound/core/spectrogram_processing/stft.py
@@ -235,6 +235,7 @@ class Stft(SpectrogramProcessingParent):
         """Plot signals.
 
         This method plots the STFT amplitude and the associated phase.
+
         Parameters
         ----------
         reference_value : float, default: 1.0

--- a/src/ansys/sound/core/spectrogram_processing/stft.py
+++ b/src/ansys/sound/core/spectrogram_processing/stft.py
@@ -246,6 +246,12 @@ class Stft(SpectrogramProcessingParent):
             raise PyAnsysSoundException(
                 f"Output is not processed yet. Use the `{__class__.__name__}.process()` method."
             )
+
+        if reference_value <= 0:
+            raise PyAnsysSoundException(
+                "Reference value for dB conversion must be strictly greater than 0."
+            )
+
         magnitude = self.get_stft_magnitude_as_nparray()
         unit = self.get_output()[0].unit
         mag_unit = unit if isinstance(unit, str) else unit[1]

--- a/src/ansys/sound/core/spectrogram_processing/stft.py
+++ b/src/ansys/sound/core/spectrogram_processing/stft.py
@@ -231,16 +231,23 @@ class Stft(SpectrogramProcessingParent):
         output = self.get_output_as_nparray()
         return np.arctan2(np.imag(output), np.real(output))
 
-    def plot(self):
+    def plot(self, reference_value: float = 1.0):
         """Plot signals.
 
         This method plots the STFT amplitude and the associated phase.
+        Parameters
+        ----------
+        reference_value : float, default: 1.0
+            Reference STFT amplitude value for dB conversion. For example, for an input sound
+            pressure signal, the reference value is typically 2e-5 (Pa).
         """
         if self._output is None:
             raise PyAnsysSoundException(
                 f"Output is not processed yet. Use the `{__class__.__name__}.process()` method."
             )
         magnitude = self.get_stft_magnitude_as_nparray()
+        unit = self.get_output()[0].unit
+        mag_unit = unit if isinstance(unit, str) else unit[1]
         freq_unit = self.get_output()[0].time_freq_support.time_frequencies.unit
         time_unit = self.get_output().time_freq_support.time_frequencies.unit
 
@@ -248,7 +255,7 @@ class Stft(SpectrogramProcessingParent):
         half_nfft = int(np.shape(magnitude)[0] / 2) + 1
 
         np.seterr(divide="ignore")
-        magnitude = 20 * np.log10(magnitude[0:half_nfft, :])
+        magnitude = 20 * np.log10(magnitude[0:half_nfft, :] / reference_value)
         np.seterr(divide="warn")
         phase = self.get_stft_phase_as_nparray()
         phase = phase[0:half_nfft, :]
@@ -264,7 +271,7 @@ class Stft(SpectrogramProcessingParent):
         # Plotting
         f, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
         p = ax1.imshow(magnitude, origin="lower", aspect="auto", cmap="jet", extent=extent)
-        f.colorbar(p, ax=ax1, label=f"Amplitude (dBSPL)")
+        f.colorbar(p, ax=ax1, label=f"Amplitude (dB re {reference_value} {mag_unit})")
         ax1.set_title("Amplitude")
         ax1.set_ylabel(f"Frequency ({freq_unit})")
         p = ax2.imshow(phase, origin="lower", aspect="auto", cmap="jet", extent=extent)

--- a/src/ansys/sound/core/spectrogram_processing/stft.py
+++ b/src/ansys/sound/core/spectrogram_processing/stft.py
@@ -272,7 +272,7 @@ class Stft(SpectrogramProcessingParent):
         # Plotting
         f, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
         p = ax1.imshow(magnitude, origin="lower", aspect="auto", cmap="jet", extent=extent)
-        f.colorbar(p, ax=ax1, label=f"Amplitude (dB re {reference_value} {mag_unit})")
+        f.colorbar(p, ax=ax1, label=f"Amplitude (dB re. {reference_value} {mag_unit})")
         ax1.set_title("Amplitude")
         ax1.set_ylabel(f"Frequency ({freq_unit})")
         p = ax2.imshow(phase, origin="lower", aspect="auto", cmap="jet", extent=extent)

--- a/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
+++ b/src/ansys/sound/core/standard_levels/octave_levels_from_psd.py
@@ -69,10 +69,10 @@ class OctaveLevelsFromPSD(FractionalOctaveLevelsFromPSDParent, min_sound_version
         if len(self.frequency_weighting) > 0:
             ylabel = (
                 f"{self.frequency_weighting}-weighted octave-band level "
-                f"(dB{self.frequency_weighting} re {self.reference_value})"
+                f"(dB{self.frequency_weighting} re. {self.reference_value})"
             )
         else:
-            ylabel = f"Octave-band level (dB re {self.reference_value})"
+            ylabel = f"Octave-band level (dB re. {self.reference_value})"
 
         plt.figure()
         plt.bar(freq_str, levels)

--- a/src/ansys/sound/core/standard_levels/overall_level.py
+++ b/src/ansys/sound/core/standard_levels/overall_level.py
@@ -92,10 +92,10 @@ class OverallLevel(StandardLevelsParent):
         str_name = f'"{self.signal.name}"' if self.signal is not None else "Not set"
         if len(self.frequency_weighting) > 0:
             str_frequency_weighting = self.frequency_weighting
-            unit = f"dB{self.frequency_weighting} (re {self.reference_value})"
+            unit = f"dB{self.frequency_weighting} re. {self.reference_value}"
         else:
             str_frequency_weighting = "None"
-            unit = f"dB (re {self.reference_value})"
+            unit = f"dB re. {self.reference_value}"
         str_level = f"{self._output:.1f} {unit}" if self._output is not None else "Not processed"
 
         return (

--- a/src/ansys/sound/core/xtract/xtract.py
+++ b/src/ansys/sound/core/xtract/xtract.py
@@ -244,10 +244,10 @@ class Xtract(XtractParent):
         self.__operator.run()
 
         # Stores the outputs
-        self.__output_noise_signal = self.__operator.get_output(0, types.fields_container)[0]
-        self.__output_tonal_signal = self.__operator.get_output(1, types.fields_container)[0]
-        self.__output_transient_signal = self.__operator.get_output(2, types.fields_container)[0]
-        self.__output_remainder_signal = self.__operator.get_output(3, types.fields_container)[0]
+        self.__output_noise_signal = self.__operator.get_output(0, types.field)
+        self.__output_tonal_signal = self.__operator.get_output(1, types.field)
+        self.__output_transient_signal = self.__operator.get_output(2, types.field)
+        self.__output_remainder_signal = self.__operator.get_output(3, types.field)
 
         self._output = (
             self.__output_noise_signal,

--- a/src/ansys/sound/core/xtract/xtract.py
+++ b/src/ansys/sound/core/xtract/xtract.py
@@ -35,6 +35,7 @@ from . import (
     XtractTransientParameters,
 )
 from .._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
+from ..server_helpers._check_version import _check_sound_version
 
 
 class Xtract(XtractParent):
@@ -244,10 +245,21 @@ class Xtract(XtractParent):
         self.__operator.run()
 
         # Stores the outputs
-        self.__output_noise_signal = self.__operator.get_output(0, types.field)
-        self.__output_tonal_signal = self.__operator.get_output(1, types.field)
-        self.__output_transient_signal = self.__operator.get_output(2, types.field)
-        self.__output_remainder_signal = self.__operator.get_output(3, types.field)
+        if _check_sound_version("2027.1.0"):
+            # DPF Sound bug fix #1411265
+            self.__output_noise_signal = self.__operator.get_output(0, types.field)
+            self.__output_tonal_signal = self.__operator.get_output(1, types.field)
+            self.__output_transient_signal = self.__operator.get_output(2, types.field)
+            self.__output_remainder_signal = self.__operator.get_output(3, types.field)
+        else:
+            self.__output_noise_signal = self.__operator.get_output(0, types.fields_container)[0]
+            self.__output_tonal_signal = self.__operator.get_output(1, types.fields_container)[0]
+            self.__output_transient_signal = self.__operator.get_output(2, types.fields_container)[
+                0
+            ]
+            self.__output_remainder_signal = self.__operator.get_output(3, types.fields_container)[
+                0
+            ]
 
         self._output = (
             self.__output_noise_signal,

--- a/tests/tests_sound_composer/test_sound_composer_source_control_time.py
+++ b/tests/tests_sound_composer/test_sound_composer_source_control_time.py
@@ -25,7 +25,7 @@ from unittest.mock import patch
 from ansys.dpf.core import Field
 import pytest
 
-from ansys.sound.core._pyansys_sound import PyAnsysSoundException
+from ansys.sound.core._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
 from ansys.sound.core.signal_utilities.load_wav import LoadWav
 from ansys.sound.core.sound_composer import SourceControlTime
 
@@ -37,21 +37,41 @@ def test_source_control_time_instantiation_no_file():
     """Test SourceControlTime instantiation."""
     # Test instantiation.
     control_time = SourceControlTime()
-    assert isinstance(control_time, SourceControlTime)
+    assert control_time.control is None
 
 
 def test_source_control_time_instantiation_wav_file():
     """Test SourceControlTime instantiation."""
     # Test instantiation.
     control_time = SourceControlTime(pytest.data_path_rpm_profile_as_wav)
-    assert isinstance(control_time, SourceControlTime)
+    assert control_time.control is not None
+
+
+def test_source_control_time_instantiation_wav_file_warning():
+    """Test SourceControlTime instantiation with expected unit warning."""
+    # Test instantiation with expected unit.
+    with pytest.warns(
+        PyAnsysSoundWarning,
+        match="Expected unit is ignored when loading control data from a WAV file.",
+    ):
+        control_time = SourceControlTime(pytest.data_path_rpm_profile_as_wav, expected_unit="km/h")
+    assert control_time.control is not None
+
+    # Check that the unit is that which is stored in the WAV file, not the specified one.
+    assert isinstance(control_time.control.unit, tuple)
+    assert control_time.control.unit[1] == "rpm"
 
 
 def test_source_control_time_instantiation_txt_file():
     """Test SourceControlTime instantiation."""
     # Test instantiation.
     control_time = SourceControlTime(pytest.data_path_rpm_profile_as_txt)
-    assert isinstance(control_time, SourceControlTime)
+    assert control_time.control is not None
+    assert control_time.control.unit == ""
+
+    control_time = SourceControlTime(pytest.data_path_rpm_profile_as_txt, expected_unit="RPM")
+    assert control_time.control is not None
+    assert control_time.control.unit == "RPM"
 
 
 def test_source_control_time_properties():

--- a/tests/tests_sound_composer/test_sound_composer_source_control_time.py
+++ b/tests/tests_sound_composer/test_sound_composer_source_control_time.py
@@ -23,6 +23,7 @@
 from unittest.mock import patch
 
 from ansys.dpf.core import Field
+from ansys.dpf.core.available_result import Homogeneity
 import pytest
 
 from ansys.sound.core._pyansys_sound import PyAnsysSoundException, PyAnsysSoundWarning
@@ -58,8 +59,12 @@ def test_source_control_time_instantiation_wav_file_warning():
     assert control_time.control is not None
 
     # Check that the unit is that which is stored in the WAV file, not the specified one.
-    assert isinstance(control_time.control.unit, tuple)
-    assert control_time.control.unit[1] == "rpm"
+    if pytest.SOUND_VERSION_GREATER_THAN_OR_EQUAL_TO_2026R1:
+        assert isinstance(control_time.control.unit, tuple)
+        assert control_time.control.unit[0] == Homogeneity.dimensionless
+        assert control_time.control.unit[1] == "rpm"
+    else:
+        assert control_time.control.unit == "rpm"
 
 
 def test_source_control_time_instantiation_txt_file():
@@ -67,10 +72,22 @@ def test_source_control_time_instantiation_txt_file():
     # Test instantiation.
     control_time = SourceControlTime(pytest.data_path_rpm_profile_as_txt)
     assert control_time.control is not None
-    assert control_time.control.unit == ""
 
     control_time = SourceControlTime(pytest.data_path_rpm_profile_as_txt, expected_unit="RPM")
     assert control_time.control is not None
+
+
+@pytest.mark.skipif(
+    not pytest.SOUND_VERSION_GREATER_THAN_OR_EQUAL_TO_2027R1,
+    reason="Before 2027 R1, load from text operator (wrongly) returns 'Pa' units in all cases.",
+)
+def test_source_control_time_instantiation_txt_file_with_expected_unit():
+    """Test SourceControlTime instantiation."""
+    # Test instantiation.
+    control_time = SourceControlTime(pytest.data_path_rpm_profile_as_txt)
+    assert control_time.control.unit == ""
+
+    control_time = SourceControlTime(pytest.data_path_rpm_profile_as_txt, expected_unit="RPM")
     assert control_time.control.unit == "RPM"
 
 

--- a/tests/tests_spectrogram_processing/test_spectrogram_processing_stft.py
+++ b/tests/tests_spectrogram_processing/test_spectrogram_processing_stft.py
@@ -191,11 +191,25 @@ def test_stft_plot(mock_show):
     wav_loader.process()
     signal = wav_loader.get_output()[0]
     stft = Stft(signal=signal)
+    stft.process()
+    stft.plot()
+    stft.plot(reference_value=2e-5)
+
+
+def test_stft_plot_exceptions():
+    """Test the plot method of Stft class."""
+    wav_loader = LoadWav(pytest.data_path_flute)
+    wav_loader.process()
+    signal = wav_loader.get_output()[0]
+    stft = Stft(signal=signal)
     with pytest.raises(
         PyAnsysSoundException,
         match="Output is not processed yet. Use the `Stft.process\\(\\)` method.",
     ):
         stft.plot()
     stft.process()
-    stft.plot()
-    stft.plot(reference_value=2e-5)
+    with pytest.raises(
+        PyAnsysSoundException,
+        match="Reference value for dB conversion must be strictly greater than 0.",
+    ):
+        stft.plot(reference_value=0.0)

--- a/tests/tests_spectrogram_processing/test_spectrogram_processing_stft.py
+++ b/tests/tests_spectrogram_processing/test_spectrogram_processing_stft.py
@@ -198,3 +198,4 @@ def test_stft_plot(mock_show):
         stft.plot()
     stft.process()
     stft.plot()
+    stft.plot(reference_value=2e-5)

--- a/tests/tests_standard_levels/test_standard_levels_level_over_time.py
+++ b/tests/tests_standard_levels/test_standard_levels_level_over_time.py
@@ -40,7 +40,7 @@ EXP_STR_ALL_SET = (
     "\tWindow size: 5000.0 ms\n\tAnalysis window: HANN\nMaximum level: Not processed"
 )
 if pytest.SOUND_VERSION_GREATER_THAN_OR_EQUAL_TO_2027R1:
-    # bug fix in DPF Sound 2026 R1 ID#1452856
+    # bug fix in DPF Sound 2027 R1 ID#1452856
     EXP_STR_ALL_PROCESSED = (
         'LevelOverTime object.\nData\n\tSignal: "flute"\n\tScale type: dB\n'
         "\tReference value: 2e-05\n\tFrequency weighting: None\n\tTime weighting: Custom\n"

--- a/tests/tests_standard_levels/test_standard_levels_level_over_time.py
+++ b/tests/tests_standard_levels/test_standard_levels_level_over_time.py
@@ -45,7 +45,7 @@ if pytest.SOUND_VERSION_GREATER_THAN_OR_EQUAL_TO_2026R1:
         'LevelOverTime object.\nData\n\tSignal: "flute"\n\tScale type: dB\n'
         "\tReference value: 2e-05\n\tFrequency weighting: None\n\tTime weighting: Custom\n"
         "\tTime step: 100.0 ms\n\tWindow size: 5000.0 ms\n\tAnalysis window: HANN\n"
-        "Maximum level: 89.2 dB (re. 2e-05 Pa)"
+        "Maximum level: 89.2 dB re. 2e-05 Pa"
     )
 else:
     EXP_STR_ALL_PROCESSED = (

--- a/tests/tests_standard_levels/test_standard_levels_level_over_time.py
+++ b/tests/tests_standard_levels/test_standard_levels_level_over_time.py
@@ -39,13 +39,21 @@ EXP_STR_ALL_SET = (
     "\tFrequency weighting: None\n\tTime weighting: Custom\n\tTime step: 100.0 ms\n"
     "\tWindow size: 5000.0 ms\n\tAnalysis window: HANN\nMaximum level: Not processed"
 )
-if pytest.SOUND_VERSION_GREATER_THAN_OR_EQUAL_TO_2026R1:
-    # bug fix in DPF Sound 2026 R1 ID#1288971
+if pytest.SOUND_VERSION_GREATER_THAN_OR_EQUAL_TO_2027R1:
+    # bug fix in DPF Sound 2026 R1 ID#1452856
     EXP_STR_ALL_PROCESSED = (
         'LevelOverTime object.\nData\n\tSignal: "flute"\n\tScale type: dB\n'
         "\tReference value: 2e-05\n\tFrequency weighting: None\n\tTime weighting: Custom\n"
         "\tTime step: 100.0 ms\n\tWindow size: 5000.0 ms\n\tAnalysis window: HANN\n"
         "Maximum level: 89.2 dB re. 2e-05 Pa"
+    )
+elif pytest.SOUND_VERSION_GREATER_THAN_OR_EQUAL_TO_2026R1:
+    # bug fix in DPF Sound 2026 R1 ID#1288971
+    EXP_STR_ALL_PROCESSED = (
+        'LevelOverTime object.\nData\n\tSignal: "flute"\n\tScale type: dB\n'
+        "\tReference value: 2e-05\n\tFrequency weighting: None\n\tTime weighting: Custom\n"
+        "\tTime step: 100.0 ms\n\tWindow size: 5000.0 ms\n\tAnalysis window: HANN\n"
+        "Maximum level: 89.2 dB (re. 2e-05 Pa)"
     )
 else:
     EXP_STR_ALL_PROCESSED = (

--- a/tests/tests_standard_levels/test_standard_levels_overall_level.py
+++ b/tests/tests_standard_levels/test_standard_levels_overall_level.py
@@ -38,7 +38,7 @@ EXP_STR_ALL_SET = (
 )
 EXP_STR_ALL_PROCESSED = (
     'OverallLevel object.\nData\n\tSignal: "flute"\n\tScale type: dB\n\tReference value: 2e-05\n'
-    "\tFrequency weighting: A\nOutput level value: 86.7 dBA (re 2e-05)"
+    "\tFrequency weighting: A\nOutput level value: 86.7 dBA re. 2e-05"
 )
 EXP_LEVEL_DEFAULT = -5.76525
 EXP_LEVEL_RMS = 0.514917


### PR DESCRIPTION
## Main purpose
Following bug fixes in `ansys-sound` package, relating to unit issues and Xtract output type, a few adjustements were necessary in PyAnsys Sound to accomodate the changes:
- Countermeasures for preiously ill-set units were removed
- Class `Xtract` now retrieves operator outputs as `Field` objects, instead of `FieldsContainer` objects previously

## Other changes
- Both `str` and `tuple` cases are now supported for known non-standard units in plots. It was previously decided to only consider the `tuple` case for these units, but that only works with version _26.1_ of the `ansys-sound`'s package or higher. With an older version (_25.2_), the unit is still returned as a mere `str`, and units displayed in plot axes would be wrong (for example, for a graph of loudness in sone, the axis would read "N (o)" instead of "N (sone)", because of the itemization done under the assumption that a `tuple` unit is returned).
- `Stft.plot()` had an error in that the STFT magnitude's axis would read "dBSPL" while the actual values displayed were in dBFS (i.e. no reference value was used). See for example: https://sound.docs.pyansys.com/version/stable/examples/gallery_examples/003_compute_stft.html#compute-and-plot-stft
<img width="592" height="219" alt="image" src="https://github.com/user-attachments/assets/c377938c-9768-40af-93a0-63e15b75f7aa" />.
To remedy this, a `reference_value` argument is added to the method to allow consistent values and axis, regardless of the unit considered.
- Some minor changes in displayed dB units out of consistency throughout PyAnsys Sound